### PR TITLE
Fix validation errors per RELAX-NG

### DIFF
--- a/src/set00_Preliminaries.mbx
+++ b/src/set00_Preliminaries.mbx
@@ -1,26 +1,30 @@
 <section xml:id="section-00-preliminaries">
   <title>Preliminaries</title>
   <introduction>
-    <ul>
-      <li>Add, subtract, multiply and divide signed numbers.</li>
-      <li>Evaluate expressions including absolute value by substituting given values.</li>
-      <li>Simplify algebraic expressions by using the order of operations, distributing, and combining like terms.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Add, subtract, multiply and divide signed numbers.</li>
+        <li>Evaluate expressions including absolute value by substituting given values.</li>
+        <li>Simplify algebraic expressions by using the order of operations, distributing, and combining like terms.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection xml:id="subsection-integer-addition-and-subtraction">
     <title>Integer Addition and Subtraction</title>
     <p>Here is a picture of the integers on a number line:</p>
 <!--    <figure xml:id="figure-numberline"> -->
-      <image xml:id="numberline">
-        <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-          <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \end{tikzpicture}]]></latex-image-code>
+      <sidebyside>
+        <image xml:id="numberline">
+          <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
+                <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \end{tikzpicture}]]></latex-image-code>
         </image>
+      </sidebyside>
 <!--      </figure> -->
-      <p>The number line actually goes on forever in both directions.  
+      <p>The number line actually goes on forever in both directions.
 <!--NOTE: THE FOLLOWING PART WAS WRITTEN BY RAC -->
-        We designate one point to represent "zero", <m>0,</m> and use it as a reference point.  Next, we choose a "unit" of measure.  The number <m>1</m> is one "unit" to the right of zero.  The number <m>2</m> is a distance of two units to the right of zero and so on. The <term>positive integers</term>, <m>1, 2, 3, \dots</m>, represent whole units of distances to the right of <m>0.</m> The
+        We designate one point to represent <q>zero</q>, <m>0,</m> and use it as a reference point.  Next, we choose a <q>unit</q> of measure.  The number <m>1</m> is one <q>unit</q> to the right of zero.  The number <m>2</m> is a distance of two units to the right of zero and so on. The <term>positive integers</term>, <m>1, 2, 3, \dots</m>, represent whole units of distances to the right of <m>0.</m> The
         <term>negative integers</term>, <m>-1, -2, -3, \dots</m>, represent whole units of distances to the left of <m>0.</m>  Some facts to note are:
-<!--END OF TEXT WRITTEN BY RAC -->        
+<!--END OF TEXT WRITTEN BY RAC -->
         <ul>
           <li>The integer
             <m>0</m> is neither positive nor negative. It is not to the right or left of itself.
@@ -52,26 +56,23 @@
           <m>3</m> to
           <m>1</m>
         </title>
-        <p>
           <sidebyside widths="55% 40%" valign="middle">
-       <!--     <figure xml:id="figure-numberline-ex-1plus3"> -->
-              <image xml:id="numberline-ex-1plus3">
-                <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=green, ->] (0:1) arc (180:15:.5); \draw[color=green, ->] (0:2) arc (180:15:.5); \draw[color=green, ->] (0:3) arc (180:15:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=green] (4,0) circle (.1); \end{tikzpicture}]]></latex-image-code>
-                </image>
-        <!--      </figure> -->
-              <paragraphs>
-                <p>Plot
-                  <m>1+3</m>: Start at
-                  <m>1</m> on the number line
-                </p>
-                <p>Move three places to the right</p>
-                <p>Our Solution:
-                  <m>4\checkmark</m> (We knew that!)
-                </p>
-              </paragraphs>
-            </sidebyside>
-          </p>
+            <image xml:id="numberline-ex-1plus3">
+              <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
+                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=green, ->] (0:1) arc (180:15:.5); \draw[color=green, ->] (0:2) arc (180:15:.5); \draw[color=green, ->] (0:3) arc (180:15:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=green] (4,0) circle (.1); \end{tikzpicture}]]>
+              </latex-image-code>
+            </image>
+            <paragraphs>
+              <p>Plot
+                <m>1+3</m>: Start at
+                <m>1</m> on the number line
+              </p>
+              <p>Move three places to the right</p>
+              <p>Our Solution:
+                <m>4\checkmark</m> (We knew that!)
+              </p>
+            </paragraphs>
+          </sidebyside>
         </example>
 
         <p>Similarly, adding a
@@ -79,39 +80,37 @@
           <em>left</em>
           <m>\leftarrow</m> on the number line.
         </p>
-                  <example xml:id="example-add-neg-2-to-neg-1">
-            <title>Add
-              <m>-2</m> to
-              <m>-1</m>
-            </title>
-            <!-- Our own-->
-            <p>
-              <sidebyside widths="55% 40%" valign="middle">
-           <!--     <figure xml:id="figure-numberline-ex-neg1minus2"> -->
-                  <image xml:id="numberline-ex-neg1minus2">
-                    <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-                      <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:-1) arc (0:165:.5); \draw[color=red, ->] (0:-2) arc (0:165:.5); \filldraw[color=blue] (-1,0) circle (.1); \filldraw[color=red] (-3,0) circle (.1); \end{tikzpicture}]]></latex-image-code>
-                    </image>
-          <!--        </figure> -->
-                  <paragraphs>
-                    <p>Plot
-                      <m>(-1)+(-2)</m>: Start at
-                      <m>-1</m> on the number line
-                    </p>
-                    <p>Move two places to left</p>
-                    <p>Our Solution:
-                      <m>-3\checkmark</m>
-                    </p>
-                  </paragraphs>
-                </sidebyside>
-              </p>
-            </example>
-            <p>Notice in 
-              <xref ref="example-add-neg-2-to-neg-1" autoname="yes" /> that adding two negative numbers is equivalent to adding the two corresponding positive numbers, but the final result is negative:
-              <m>1+2=3</m> and
-              <m>-1+(-2)=-3</m>.
-              </p>
-            
+        <example xml:id="example-add-neg-2-to-neg-1">
+          <title>Add
+            <m>-2</m> to
+            <m>-1</m>
+          </title>
+          <!-- Our own-->
+          <sidebyside widths="55% 40%" valign="middle">
+              <image xml:id="numberline-ex-neg1minus2">
+                <latex-image-code>
+                  <![CDATA[\begin{tikzpicture}[scale = 0.5, transform shape] \draw[
+                    <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:-1) arc (0:165:.5); \draw[color=red, ->] (0:-2) arc (0:165:.5); \filldraw[color=blue] (-1,0) circle (.1); \filldraw[color=red] (-3,0) circle (.1); \end{tikzpicture}]]>
+                </latex-image-code>
+              </image>
+              <paragraphs>
+                <p>Plot
+                  <m>(-1)+(-2)</m>: Start at
+                  <m>-1</m> on the number line
+                </p>
+                <p>Move two places to left</p>
+                <p>Our Solution:
+                  <m>-3\,\checkmark</m>
+                </p>
+              </paragraphs>
+            </sidebyside>
+          </example>
+          <p>Notice in
+            <xref ref="example-add-neg-2-to-neg-1" autoname="yes" /> that adding two negative numbers is equivalent to adding the two corresponding positive numbers, but the final result is negative:
+            <m>1+2=3</m> and
+            <m>-1+(-2)=-3</m>.
+          </p>
+
 <!--              <p>  In
               <xref ref="example-add-neg-3-to-1" autoname="yes"/> we see that adding a negative number to a positive number can be computed by first subtracting the corresponding positive integers, but the final result is negative:
               <m>3-1=2</m> and
@@ -124,84 +123,83 @@
               <md>
                 <mrow>\text{Compute }-4+(-11) \amp\amp\amp \text{Adding two negatives: add positives}</mrow>
                 <mrow>4+11=15\amp\amp\amp\text{Our result should be negative}</mrow>
-                <mrow>-4+(-11)=-15 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                <mrow>-4+(-11)=-15 \amp\amp\amp \text{Our Solution}\,\checkmark</mrow>
               </md>
             </p>
             </example>
 
-            <p>If you were to sketch out a number line to solve <xref ref="example-add-two-negatives" autoname="yes" />, you would start at 
+            <p>If you were to sketch out a number line to solve <xref ref="example-add-two-negatives" autoname="yes" />, you would start at
               <m>-4</m> then move left
               <m>11</m> positions.  The result would end up at
               <m>-15</m>.
             </p>
             <p>
-            Now let's consider adding two numbers with opposite signs.  
+            Now let's consider adding two numbers with opposite signs.
             </p>
         <example xml:id="example-add-neg-3-to-1">
           <title>Add
             <m>-3</m> to
             <m>1</m>
           </title>
-          <p>
-            <sidebyside widths="55% 40%" valign="middle">
+          <sidebyside widths="55% 40%" valign="middle">
          <!--     <figure xml:id="figure-numberline-ex-1minus3"> -->
-                <image xml:id="numberline-ex-1minus3">
-                  <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-                    <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:1) arc (0:165:.5); \draw[color=red, ->] (0:0) arc (0:165:.5); \draw[color=red, ->] (0:-1) arc (0:165:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=red] (-2,0) circle (.1); \end{tikzpicture}]]></latex-image-code>
-                  </image>
-         <!--       </figure> -->
-                <paragraphs>
-                  <p>Plot
-                    <m>1+(-3)</m>: Start at
-                    <m>1</m> on the number line
-                  </p>
-                  <p>Move three places to left</p>
-                  <p>Our Solution:
-                    <m>-2\checkmark</m>
-                  </p>
-                </paragraphs>
-              </sidebyside>
-            </p>
-          </example>
+            <image xml:id="numberline-ex-1minus3">
+              <latex-image-code>
+                <![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
+                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:1) arc (0:165:.5); \draw[color=red, ->] (0:0) arc (0:165:.5); \draw[color=red, ->] (0:-1) arc (0:165:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=red] (-2,0) circle (.1); \end{tikzpicture}]]>
+              </latex-image-code>
+            </image>
+            <paragraphs>
+              <p>Plot
+                <m>1+(-3)</m>: Start at
+                <m>1</m> on the number line
+              </p>
+              <p>Move three places to left</p>
+              <p>Our Solution:
+                <m>-2\checkmark</m>
+              </p>
+            </paragraphs>
+          </sidebyside>
+        </example>
 
-            <p>When adding integers with opposite signs use the corresponding positive integers, we subtract the smaller from the larger,  then use the sign from the larger number in our result. This means if the larger number is positive, the answer is positive. If the larger number is negative, the answer is negative. Consider the following examples:</p>
+        <p>When adding integers with opposite signs use the corresponding positive integers, we subtract the smaller from the larger,  then use the sign from the larger number in our result. This means if the larger number is positive, the answer is positive. If the larger number is negative, the answer is negative. Consider the following examples:</p>
 
             <example>
               <title>Add Integers of Different Signs</title>
               <p>
-              <md>
-                <mrow>\text{Compute }-5+2 \amp\amp\amp \text{Different signs: subtract first}</mrow>
-                <mrow>5-2=3\amp\amp\amp\text{use sign from bigger number (\(5\)), negative}</mrow>
-                <mrow>-3 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
-            </p>
+                <md>
+                  <mrow>\text{Compute }-5+2 \amp\amp\amp \text{Different signs: subtract first}</mrow>
+                  <mrow>5-2=3\amp\amp\amp\text{use sign from bigger number (\(5\)), negative}</mrow>
+                  <mrow>-3 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
             <example>
               <title>Add Integers of Different Signs</title>
               <p>
-              <md>
-                <mrow>\text{Compute }-14+20 \amp\amp\amp \text{Different signs: subtract first}</mrow>
-                <mrow>20-14=6\amp\amp\amp\text{use sign from bigger number (\(20\)), positive}</mrow>
-                <mrow>6 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
-            </p>
+                <md>
+                  <mrow>\text{Compute }-14+20 \amp\amp\amp \text{Different signs: subtract first}</mrow>
+                  <mrow>20-14=6\amp\amp\amp\text{use sign from bigger number (\(20\)), positive}</mrow>
+                  <mrow>6 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
-            <p>To subtract a signed number, we 
+            <p>To subtract a signed number, we
               <em>add the opposite</em> of the number after the subtraction sign using the rules for addition described above.
             </p>
 
             <example>
               <title>Subtract Integers: add the opposite</title>
-              <p>
-              <md>
-                <mrow>\text{Compute }7-(-6) \amp\amp\amp \text{
-                  Add the opposite of \(-6\)}</mrow>
-                <mrow>7+(6) \amp\amp\amp \text{Addition of positive integers}</mrow>
-                <mrow>13 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
-            </p>
+                <p>
+                <md>
+                  <mrow>\text{Compute }7-(-6) \amp\amp\amp \text{
+                    Add the opposite of \(-6\)}</mrow>
+                  <mrow>7+(6) \amp\amp\amp \text{Addition of positive integers}</mrow>
+                  <mrow>13 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
             <example>
@@ -268,7 +266,7 @@
             </p>
             </example>
 
-            <p><term>Exponents</term> are used to denote repeated multiplication of a number times itself.  We call the number the <text>base</text> of the expoenent.</p>
+            <p><term>Exponents</term> are used to denote repeated multiplication of a number times itself.  We call the number the <term>base</term> of the exponent.</p>
             <example>
               <title>Exponents: Evaluate
                 <m>6^2</m>
@@ -296,11 +294,11 @@
 
             <p>Be careful when working with integers. For example, compare the expression
               <m>-3-8</m> with
-              <m>-3(-8)</m>. The second expression is a product. If there is no operation symbol between parentheses, we assume we are multiplying. On the other hand, the expression 
-              <m>-3-8</m> is subtraction. 
+              <m>-3(-8)</m>. The second expression is a product. If there is no operation symbol between parentheses, we assume we are multiplying. On the other hand, the expression
+              <m>-3-8</m> is subtraction.
             </p>
             <p>Also, be careful not to mix up the rules for adding and subtracting integers with the rules for multiplying and dividing integers. For example,
-              <m>-3+(-7)=-10</m>, but 
+              <m>-3+(-7)=-10</m>, but
               <m>(-3)(-7)=21</m>.
             </p>
           </subsection>
@@ -316,7 +314,7 @@
               <p>
               <md>
                 <mrow>\underbrace{2+5} \cdot 3 \amp\amp\amp \text{Add First} \amp\amp\amp \color{red}{\text{versus}} \amp\amp\amp 2+\underbrace{5 \cdot 3} \amp\amp\amp \text{Multiply First}</mrow>
-                <mrow>7 \cdot 3 \amp\amp\amp \text{Then Multiply} 
+                <mrow>7 \cdot 3 \amp\amp\amp \text{Then Multiply}
                   \amp\amp\amp\amp\amp\amp 2+15\amp\amp\amp \text{Then Add}</mrow>
                 <mrow>21 \amp\amp\amp \text{Solution??} \amp\amp\amp\amp\amp\amp 17 \amp\amp\amp \text{Solution??}</mrow>
               </md>
@@ -327,23 +325,23 @@
             <m>17</m>, is the correct method. This list then is the order of operations we will use to simplify expressions.
             </p>
 
-<!--            <table> -->
+            <sidebyside>
               <tabular halign="center">
-                  
+
                 <row bottom="minor"><cell>Order of Operations:</cell></row>
                 <row><cell>parentheses (Grouping)</cell></row>
                 <row><cell>Exponents</cell></row>
                 <row><cell>Multiply and Divide (Left to Right)</cell></row>
                 <row><cell>Add and Subtract (Left to Right)</cell></row>
-                </tabular>
- <!--               </table>  -->
-              <p>
-                 Multiply and Divide are on the same level because they are the same operation (division is just multiplying by the reciprocal). This means they must be done left to right, so some problems we will divide first, others we will multiply first. The same is true for adding and subtracting (subtracting is just adding the opposite). Often students use the word
-            <term>PEMDAS</term> to remember the order of operations, as the first letter of each operation creates the word
-            <term>PEMDAS</term>.  However, it is the author's suggestion to think about
-            <term>PEMDAS</term> as a vertical word written as:
-          </p>
- <!--           <table>  -->
+              </tabular>
+            </sidebyside>
+            <p>
+              Multiply and Divide are on the same level because they are the same operation (division is just multiplying by the reciprocal). This means they must be done left to right, so some problems we will divide first, others we will multiply first. The same is true for adding and subtracting (subtracting is just adding the opposite). Often students use the word
+              <term>PEMDAS</term> to remember the order of operations, as the first letter of each operation creates the word
+              <term>PEMDAS</term>.  However, it is the author's suggestion to think about
+              <term>PEMDAS</term> as a vertical word written as:
+            </p>
+            <sidebyside>
               <tabular halign="center">
 
                 <row><cell><m>P</m></cell></row>
@@ -352,13 +350,11 @@
                 <row><cell><m>D</m></cell></row>
                 <row><cell><m>A</m></cell></row>
                 <row><cell><m>S</m></cell></row>
-                </tabular>
-  <!--              </table>  -->
-            
+              </tabular>
+            </sidebyside>
             <p>so we don't forget that multiplication and division are done left to right (same with addition and subtraction). Another way students remember the order of operations is to think of a phrase such as
               <q>Please Excuse My Dear Aunt Sally</q> where each word starts with the same letters as the order of operations start with.
             </p>
--->
             <example>
               <title>Order of Operations</title>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 25 pg 19-->
@@ -382,11 +378,13 @@
               <p>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 26 pg 19-->
               </p>
-              <md>
-                <mrow>\text{Compute }\underbrace{30 \div 3} \cdot 2 \amp\amp\amp \text{Divide first (left to right!)}</mrow>
-                <mrow>\underbrace{10 \cdot 2} \amp\amp\amp \text{Multiply}</mrow>
-                <mrow>20 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+              <p>
+                <md>
+                  <mrow>\text{Compute }\underbrace{30 \div 3} \cdot 2 \amp\amp\amp \text{Divide first (left to right!)}</mrow>
+                  <mrow>\underbrace{10 \cdot 2} \amp\amp\amp \text{Multiply}</mrow>
+                  <mrow>20 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
             <example>
@@ -433,7 +431,7 @@
 
 <!--            <example>
               <title>Order of Operations</title>
---> 
+-->
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 27 pg 19   Might want to put this in as an "extra" example later. It's a lot more difficult than what we ask them to do in WW.  -rac 8/9/2017
           -->
 <!--
@@ -494,7 +492,7 @@
 
             <p>Whenever we replace a variable with a number, we put the new number inside parentheses. Notice the
               <m>3</m> and
-              <m>5</m> in the previous <xref ref="example-evaluate-expression" autoname="yes" /> are in parentheses. This is to preserve operations that are sometimes lost inwithout parentheses. Sometimes the parentheses won't make a difference, but it is a good habit to always use them to prevent problems later.
+              <m>5</m> in the previous <xref ref="example-evaluate-expression" autoname="yes" /> are in parentheses. This is to preserve operations that are sometimes lost without parentheses. Sometimes the parentheses won't make a difference, but it is a good habit to always use them to prevent problems later.
             </p>
 
             <example>
@@ -512,7 +510,7 @@
               </md>
             </p>
             </example>
-            <p>It will be more common in our study of algebra that we do not know the value of the variables. In this case, we will have to simplify what we can and leave the variables in our final solution. 
+            <p>It will be more common in our study of algebra that we do not know the value of the variables. In this case, we will have to simplify what we can and leave the variables in our final solution.
             </p>
             <p>One way we can simplify expressions is to combine like terms. Like terms are terms where the variables match exactly (exponents included). Examples of like terms would be
               <m>3xy</m> and
@@ -527,10 +525,10 @@
               <title>Combine Like Terms</title>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 32 pg 23-->
               <p>
-              <md>
-                <mrow>5x-2y -8x+7y \amp\amp\amp \text{Combine like terms \(5x-8x\) and \(-2y +7y\)}</mrow>
-                <mrow>-3x+5y \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+                <md>
+                  <mrow>5x-2y -8x+7y \amp\amp\amp \text{Combine like terms }5x-8x\text{ and }-2y +7y</mrow>
+                  <mrow>-3x+5y \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
             </p>
             </example>
 
@@ -552,15 +550,14 @@
                 </assemblage>
             <p>When we combine like terms we interpret minus signs as part of the term. This means the following term is a negative term, the sign always stays with the term.  We then add the terms together.</p>
 
-            <p>Another simplification technique uses the <term>distributive property</term>. 
+            <p>Another simplification technique uses the <term>distributive property</term>.
             </p>
-
-            <mdn>
-              <mrow xml:id="distributive-property">\text{Distributive Property: }
-                a(b+c)=ab+ac
-              </mrow>
-            </mdn>
-            
+            <p>
+              <mdn>
+                <mrow xml:id="distributive-property">\text{Distributive Property: } a(b+c)=ab+ac
+                </mrow>
+              </mdn>
+            </p>
             <p>Several examples of using the distributive property are given below.</p>
 
             <example>
@@ -593,7 +590,7 @@
 
             <p>It is possible to distribute just a negative through parentheses. If we have a negative in front of parentheses we can think of it like a
               <m>-1</m> in front and distribute the
-              <m>-1</m> through. 
+              <m>-1</m> through.
             </p>
 
             <example>
@@ -608,7 +605,7 @@
             </p>
             </example>
 
-            <p>We may need to use both the distributive property and combingin like terms to simplify an expression. Order of operations tells us to multiply (distribute) first then add or subtract last (combine like terms). Thus we simplify in two steps, distribute then combine.</p>
+            <p>We may need to use both the distributive property and combining like terms to simplify an expression. Order of operations tells us to multiply (distribute) first then add or subtract last (combine like terms). Thus we simplify in two steps, distribute then combine.</p>
 
             <example>
               <title>Simplify</title>
@@ -636,7 +633,7 @@
 
             <p>In the previous <xref ref="example-simplify" autoname="yes" /> we distributed
               <m>-2</m>, not just
-              <m>2</m>. This is because a negative sign goes with the number after it. Note that <m>-2</m> times <m>-5</m> is positive 
+              <m>2</m>. This is because a negative sign goes with the number after it. Note that <m>-2</m> times <m>-5</m> is positive
               <m>10.</m> Following are more involved examples of distributing and combining like terms.
             </p>
 
@@ -645,24 +642,28 @@
               <p>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 39 pg 24-->
               </p>
-              <md>
-                <mrow>2(5x-8)-6(4x+3) \amp\amp\amp \text{Distribute \(2\) into first parentheses and \(-6\) into second}</mrow>
-                <mrow>10x-16-24x-18 \amp\amp\amp \text{Combine like terms \(10x-24x\) and \(-16-18\)}</mrow>
-                <mrow>-14x-34 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+              <p>
+                <md>
+                  <mrow>2(5x-8)-6(4x+3) \amp\amp\amp \text{Distribute \(2\) into first parentheses and \(-6\) into second}</mrow>
+                  <mrow>10x-16-24x-18 \amp\amp\amp \text{Combine like terms \(10x-24x\) and \(-16-18\)}</mrow>
+                  <mrow>-14x-34 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
             <example>
               <title>Simplify</title>
               <p>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 40 pg 24-->
               </p>
-              <md>
-                <mrow>4(3x-8)-(2x-7) \amp\amp\amp \text{Negative (subtract) in middle can be thought of as \(-1\)}</mrow>
-                <mrow>4(3x-8)-1(2x-7) \amp\amp\amp \text{Distribute \(4\) into first parentheses and \(-1\) into second}</mrow>
-                <mrow>12x-32-2x+7 \amp\amp\amp \text{Combine like terms \(12x-2x\) and \(-32+7\)}</mrow>
-                <mrow>10x-25 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+              <p>
+                <md>
+                  <mrow>4(3x-8)-(2x-7) \amp\amp\amp \text{Negative (subtract) in middle can be thought of as \(-1\)}</mrow>
+                  <mrow>4(3x-8)-1(2x-7) \amp\amp\amp \text{Distribute \(4\) into first parentheses and \(-1\) into second}</mrow>
+                  <mrow>12x-32-2x+7 \amp\amp\amp \text{Combine like terms \(12x-2x\) and \(-32+7\)}</mrow>
+                  <mrow>10x-25 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
           </subsection>
         </section>
- 
+

--- a/src/set00_Preliminaries.mbx
+++ b/src/set00_Preliminaries.mbx
@@ -1,26 +1,30 @@
 <section xml:id="section-00-preliminaries">
   <title>Preliminaries</title>
   <introduction>
-    <ul>
-      <li>Add, subtract, multiply and divide signed numbers.</li>
-      <li>Evaluate expressions including absolute value by substituting given values.</li>
-      <li>Simplify algebraic expressions by using the order of operations, distributing, and combining like terms.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Add, subtract, multiply and divide signed numbers.</li>
+        <li>Evaluate expressions including absolute value by substituting given values.</li>
+        <li>Simplify algebraic expressions by using the order of operations, distributing, and combining like terms.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection xml:id="subsection-integer-addition-and-subtraction">
     <title>Integer Addition and Subtraction</title>
     <p>Here is a picture of the integers on a number line:</p>
 <!--    <figure xml:id="figure-numberline"> -->
-      <image xml:id="numberline">
-        <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-          <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \end{tikzpicture}]]></latex-image-code>
+      <sidebyside>
+        <image xml:id="numberline">
+          <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
+                <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \end{tikzpicture}]]></latex-image-code>
         </image>
+      </sidebyside>
 <!--      </figure> -->
-      <p>The number line actually goes on forever in both directions.  
+      <p>The number line actually goes on forever in both directions.
 <!--NOTE: THE FOLLOWING PART WAS WRITTEN BY RAC -->
-        We designate one point to represent "zero", <m>0,</m> and use it as a reference point.  Next, we choose a "unit" of measure.  The number <m>1</m> is one "unit" to the right of zero.  The number <m>2</m> is a distance of two units to the right of zero and so on. The <term>positive integers</term>, <m>1, 2, 3, \dots</m>, represent whole units of distances to the right of <m>0.</m> The
+        We designate one point to represent <q>zero</q>, <m>0,</m> and use it as a reference point.  Next, we choose a <q>unit</q> of measure.  The number <m>1</m> is one <q>unit</q> to the right of zero.  The number <m>2</m> is a distance of two units to the right of zero and so on. The <term>positive integers</term>, <m>1, 2, 3, \dots</m>, represent whole units of distances to the right of <m>0.</m> The
         <term>negative integers</term>, <m>-1, -2, -3, \dots</m>, represent whole units of distances to the left of <m>0.</m>  Some facts to note are:
-<!--END OF TEXT WRITTEN BY RAC -->        
+<!--END OF TEXT WRITTEN BY RAC -->
         <ul>
           <li>The integer
             <m>0</m> is neither positive nor negative. It is not to the right or left of itself.
@@ -52,26 +56,23 @@
           <m>3</m> to
           <m>1</m>
         </title>
-        <p>
           <sidebyside widths="55% 40%" valign="middle">
-       <!--     <figure xml:id="figure-numberline-ex-1plus3"> -->
-              <image xml:id="numberline-ex-1plus3">
-                <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=green, ->] (0:1) arc (180:15:.5); \draw[color=green, ->] (0:2) arc (180:15:.5); \draw[color=green, ->] (0:3) arc (180:15:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=green] (4,0) circle (.1); \end{tikzpicture}]]></latex-image-code>
-                </image>
-        <!--      </figure> -->
-              <paragraphs>
-                <p>Plot
-                  <m>1+3</m>: Start at
-                  <m>1</m> on the number line
-                </p>
-                <p>Move three places to the right</p>
-                <p>Our Solution:
-                  <m>4\checkmark</m> (We knew that!)
-                </p>
-              </paragraphs>
-            </sidebyside>
-          </p>
+            <image xml:id="numberline-ex-1plus3">
+              <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
+                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=green, ->] (0:1) arc (180:15:.5); \draw[color=green, ->] (0:2) arc (180:15:.5); \draw[color=green, ->] (0:3) arc (180:15:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=green] (4,0) circle (.1); \end{tikzpicture}]]>
+              </latex-image-code>
+            </image>
+            <paragraphs>
+              <p>Plot
+                <m>1+3</m>: Start at
+                <m>1</m> on the number line
+              </p>
+              <p>Move three places to the right</p>
+              <p>Our Solution:
+                <m>4\checkmark</m> (We knew that!)
+              </p>
+            </paragraphs>
+          </sidebyside>
         </example>
 
         <p>Similarly, adding a
@@ -79,39 +80,37 @@
           <em>left</em>
           <m>\leftarrow</m> on the number line.
         </p>
-                  <example xml:id="example-add-neg-2-to-neg-1">
-            <title>Add
-              <m>-2</m> to
-              <m>-1</m>
-            </title>
-            <!-- Our own-->
-            <p>
-              <sidebyside widths="55% 40%" valign="middle">
-           <!--     <figure xml:id="figure-numberline-ex-neg1minus2"> -->
-                  <image xml:id="numberline-ex-neg1minus2">
-                    <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-                      <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:-1) arc (0:165:.5); \draw[color=red, ->] (0:-2) arc (0:165:.5); \filldraw[color=blue] (-1,0) circle (.1); \filldraw[color=red] (-3,0) circle (.1); \end{tikzpicture}]]></latex-image-code>
-                    </image>
-          <!--        </figure> -->
-                  <paragraphs>
-                    <p>Plot
-                      <m>(-1)+(-2)</m>: Start at
-                      <m>-1</m> on the number line
-                    </p>
-                    <p>Move two places to left</p>
-                    <p>Our Solution:
-                      <m>-3\checkmark</m>
-                    </p>
-                  </paragraphs>
-                </sidebyside>
-              </p>
-            </example>
-            <p>Notice in 
-              <xref ref="example-add-neg-2-to-neg-1" autoname="yes" /> that adding two negative numbers is equivalent to adding the two corresponding positive numbers, but the final result is negative:
-              <m>1+2=3</m> and
-              <m>-1+(-2)=-3</m>.
-              </p>
-            
+        <example xml:id="example-add-neg-2-to-neg-1">
+          <title>Add
+            <m>-2</m> to
+            <m>-1</m>
+          </title>
+          <!-- Our own-->
+          <sidebyside widths="55% 40%" valign="middle">
+              <image xml:id="numberline-ex-neg1minus2">
+                <latex-image-code>
+                  <![CDATA[\begin{tikzpicture}[scale = 0.5, transform shape] \draw[
+                    <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:-1) arc (0:165:.5); \draw[color=red, ->] (0:-2) arc (0:165:.5); \filldraw[color=blue] (-1,0) circle (.1); \filldraw[color=red] (-3,0) circle (.1); \end{tikzpicture}]]>
+                </latex-image-code>
+              </image>
+              <paragraphs>
+                <p>Plot
+                  <m>(-1)+(-2)</m>: Start at
+                  <m>-1</m> on the number line
+                </p>
+                <p>Move two places to left</p>
+                <p>Our Solution:
+                  <m>-3\,\checkmark</m>
+                </p>
+              </paragraphs>
+            </sidebyside>
+          </example>
+          <p>Notice in
+            <xref ref="example-add-neg-2-to-neg-1" autoname="yes" /> that adding two negative numbers is equivalent to adding the two corresponding positive numbers, but the final result is negative:
+            <m>1+2=3</m> and
+            <m>-1+(-2)=-3</m>.
+          </p>
+
 <!--              <p>  In
               <xref ref="example-add-neg-3-to-1" autoname="yes"/> we see that adding a negative number to a positive number can be computed by first subtracting the corresponding positive integers, but the final result is negative:
               <m>3-1=2</m> and
@@ -124,84 +123,83 @@
               <md>
                 <mrow>\text{Compute }-4+(-11) \amp\amp\amp \text{Adding two negatives: add positives}</mrow>
                 <mrow>4+11=15\amp\amp\amp\text{Our result should be negative}</mrow>
-                <mrow>-4+(-11)=-15 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                <mrow>-4+(-11)=-15 \amp\amp\amp \text{Our Solution}\,\checkmark</mrow>
               </md>
             </p>
             </example>
 
-            <p>If you were to sketch out a number line to solve <xref ref="example-add-two-negatives" autoname="yes" />, you would start at 
+            <p>If you were to sketch out a number line to solve <xref ref="example-add-two-negatives" autoname="yes" />, you would start at
               <m>-4</m> then move left
               <m>11</m> positions.  The result would end up at
               <m>-15</m>.
             </p>
             <p>
-            Now let's consider adding two numbers with opposite signs.  
+            Now let's consider adding two numbers with opposite signs.
             </p>
         <example xml:id="example-add-neg-3-to-1">
           <title>Add
             <m>-3</m> to
             <m>1</m>
           </title>
-          <p>
-            <sidebyside widths="55% 40%" valign="middle">
+          <sidebyside widths="55% 40%" valign="middle">
          <!--     <figure xml:id="figure-numberline-ex-1minus3"> -->
-                <image xml:id="numberline-ex-1minus3">
-                  <latex-image-code><![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
-                    <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:1) arc (0:165:.5); \draw[color=red, ->] (0:0) arc (0:165:.5); \draw[color=red, ->] (0:-1) arc (0:165:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=red] (-2,0) circle (.1); \end{tikzpicture}]]></latex-image-code>
-                  </image>
-         <!--       </figure> -->
-                <paragraphs>
-                  <p>Plot
-                    <m>1+(-3)</m>: Start at
-                    <m>1</m> on the number line
-                  </p>
-                  <p>Move three places to left</p>
-                  <p>Our Solution:
-                    <m>-2\checkmark</m>
-                  </p>
-                </paragraphs>
-              </sidebyside>
-            </p>
-          </example>
+            <image xml:id="numberline-ex-1minus3">
+              <latex-image-code>
+                <![CDATA[\begin{tikzpicture} [scale = 0.5, transform shape] \draw[
+                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {$\x$}; \draw[color=red, ->] (0:1) arc (0:165:.5); \draw[color=red, ->] (0:0) arc (0:165:.5); \draw[color=red, ->] (0:-1) arc (0:165:.5); \filldraw[color=blue] (1,0) circle (.1); \filldraw[color=red] (-2,0) circle (.1); \end{tikzpicture}]]>
+              </latex-image-code>
+            </image>
+            <paragraphs>
+              <p>Plot
+                <m>1+(-3)</m>: Start at
+                <m>1</m> on the number line
+              </p>
+              <p>Move three places to left</p>
+              <p>Our Solution:
+                <m>-2\checkmark</m>
+              </p>
+            </paragraphs>
+          </sidebyside>
+        </example>
 
-            <p>When adding integers with opposite signs use the corresponding positive integers, we subtract the smaller from the larger,  then use the sign from the larger number in our result. This means if the larger number is positive, the answer is positive. If the larger number is negative, the answer is negative. Consider the following examples:</p>
+        <p>When adding integers with opposite signs use the corresponding positive integers, we subtract the smaller from the larger,  then use the sign from the larger number in our result. This means if the larger number is positive, the answer is positive. If the larger number is negative, the answer is negative. Consider the following examples:</p>
 
             <example>
               <title>Add Integers of Different Signs</title>
               <p>
-              <md>
-                <mrow>\text{Compute }-5+2 \amp\amp\amp \text{Different signs: subtract first}</mrow>
-                <mrow>5-2=3\amp\amp\amp\text{use sign from bigger number (\(5\)), negative}</mrow>
-                <mrow>-3 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
-            </p>
+                <md>
+                  <mrow>\text{Compute }-5+2 \amp\amp\amp \text{Different signs: subtract first}</mrow>
+                  <mrow>5-2=3\amp\amp\amp\text{use sign from bigger number (\(5\)), negative}</mrow>
+                  <mrow>-3 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
             <example>
               <title>Add Integers of Different Signs</title>
               <p>
-              <md>
-                <mrow>\text{Compute }-14+20 \amp\amp\amp \text{Different signs: subtract first}</mrow>
-                <mrow>20-14=6\amp\amp\amp\text{use sign from bigger number (\(20\)), positive}</mrow>
-                <mrow>6 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
-            </p>
+                <md>
+                  <mrow>\text{Compute }-14+20 \amp\amp\amp \text{Different signs: subtract first}</mrow>
+                  <mrow>20-14=6\amp\amp\amp\text{use sign from bigger number (\(20\)), positive}</mrow>
+                  <mrow>6 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
-            <p>To subtract a signed number, we 
+            <p>To subtract a signed number, we
               <em>add the opposite</em> of the number after the subtraction sign using the rules for addition described above.
             </p>
 
             <example>
               <title>Subtract Integers: add the opposite</title>
-              <p>
-              <md>
-                <mrow>\text{Compute }7-(-6) \amp\amp\amp \text{
-                  Add the opposite of \(-6\)}</mrow>
-                <mrow>7+(6) \amp\amp\amp \text{Addition of positive integers}</mrow>
-                <mrow>13 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
-            </p>
+                <p>
+                <md>
+                  <mrow>\text{Compute }7-(-6) \amp\amp\amp \text{
+                    Add the opposite of \(-6\)}</mrow>
+                  <mrow>7+(6) \amp\amp\amp \text{Addition of positive integers}</mrow>
+                  <mrow>13 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
             <example>
@@ -268,7 +266,7 @@
             </p>
             </example>
 
-            <p><term>Exponents</term> are used to denote repeated multiplication of a number times itself.  We call the number the <text>base</text> of the expoenent.</p>
+            <p><term>Exponents</term> are used to denote repeated multiplication of a number times itself.  We call the number the <term>base</term> of the exponent.</p>
             <example>
               <title>Exponents: Evaluate
                 <m>6^2</m>
@@ -296,11 +294,11 @@
 
             <p>Be careful when working with integers. For example, compare the expression
               <m>-3-8</m> with
-              <m>-3(-8)</m>. The second expression is a product. If there is no operation symbol between parentheses, we assume we are multiplying. On the other hand, the expression 
-              <m>-3-8</m> is subtraction. 
+              <m>-3(-8)</m>. The second expression is a product. If there is no operation symbol between parentheses, we assume we are multiplying. On the other hand, the expression
+              <m>-3-8</m> is subtraction.
             </p>
             <p>Also, be careful not to mix up the rules for adding and subtracting integers with the rules for multiplying and dividing integers. For example,
-              <m>-3+(-7)=-10</m>, but 
+              <m>-3+(-7)=-10</m>, but
               <m>(-3)(-7)=21</m>.
             </p>
           </subsection>
@@ -316,7 +314,7 @@
               <p>
               <md>
                 <mrow>\underbrace{2+5} \cdot 3 \amp\amp\amp \text{Add First} \amp\amp\amp \color{red}{\text{versus}} \amp\amp\amp 2+\underbrace{5 \cdot 3} \amp\amp\amp \text{Multiply First}</mrow>
-                <mrow>7 \cdot 3 \amp\amp\amp \text{Then Multiply} 
+                <mrow>7 \cdot 3 \amp\amp\amp \text{Then Multiply}
                   \amp\amp\amp\amp\amp\amp 2+15\amp\amp\amp \text{Then Add}</mrow>
                 <mrow>21 \amp\amp\amp \text{Solution??} \amp\amp\amp\amp\amp\amp 17 \amp\amp\amp \text{Solution??}</mrow>
               </md>
@@ -327,23 +325,23 @@
             <m>17</m>, is the correct method. This list then is the order of operations we will use to simplify expressions.
             </p>
 
-<!--            <table> -->
+            <sidebyside>
               <tabular halign="center">
-                  
+
                 <row bottom="minor"><cell>Order of Operations:</cell></row>
                 <row><cell>parentheses (Grouping)</cell></row>
                 <row><cell>Exponents</cell></row>
                 <row><cell>Multiply and Divide (Left to Right)</cell></row>
                 <row><cell>Add and Subtract (Left to Right)</cell></row>
-                </tabular>
- <!--               </table>  -->
-              <p>
-                 Multiply and Divide are on the same level because they are the same operation (division is just multiplying by the reciprocal). This means they must be done left to right, so some problems we will divide first, others we will multiply first. The same is true for adding and subtracting (subtracting is just adding the opposite). Often students use the word
-            <term>PEMDAS</term> to remember the order of operations, as the first letter of each operation creates the word
-            <term>PEMDAS</term>.  However, it is the author's suggestion to think about
-            <term>PEMDAS</term> as a vertical word written as:
-          </p>
- <!--           <table>  -->
+              </tabular>
+            </sidebyside>
+            <p>
+              Multiply and Divide are on the same level because they are the same operation (division is just multiplying by the reciprocal). This means they must be done left to right, so some problems we will divide first, others we will multiply first. The same is true for adding and subtracting (subtracting is just adding the opposite). Often students use the word
+              <term>PEMDAS</term> to remember the order of operations, as the first letter of each operation creates the word
+              <term>PEMDAS</term>.  However, it is the author's suggestion to think about
+              <term>PEMDAS</term> as a vertical word written as:
+            </p>
+            <sidebyside>
               <tabular halign="center">
 
                 <row><cell><m>P</m></cell></row>
@@ -352,13 +350,11 @@
                 <row><cell><m>D</m></cell></row>
                 <row><cell><m>A</m></cell></row>
                 <row><cell><m>S</m></cell></row>
-                </tabular>
-  <!--              </table>  -->
-            
+              </tabular>
+            </sidebyside>
             <p>so we don't forget that multiplication and division are done left to right (same with addition and subtraction). Another way students remember the order of operations is to think of a phrase such as
               <q>Please Excuse My Dear Aunt Sally</q> where each word starts with the same letters as the order of operations start with.
             </p>
--->
             <example>
               <title>Order of Operations</title>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 25 pg 19-->
@@ -382,11 +378,13 @@
               <p>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 26 pg 19-->
               </p>
-              <md>
-                <mrow>\text{Compute }\underbrace{30 \div 3} \cdot 2 \amp\amp\amp \text{Divide first (left to right!)}</mrow>
-                <mrow>\underbrace{10 \cdot 2} \amp\amp\amp \text{Multiply}</mrow>
-                <mrow>20 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+              <p>
+                <md>
+                  <mrow>\text{Compute }\underbrace{30 \div 3} \cdot 2 \amp\amp\amp \text{Divide first (left to right!)}</mrow>
+                  <mrow>\underbrace{10 \cdot 2} \amp\amp\amp \text{Multiply}</mrow>
+                  <mrow>20 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
 
             <example>
@@ -433,7 +431,7 @@
 
 <!--            <example>
               <title>Order of Operations</title>
---> 
+-->
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 27 pg 19   Might want to put this in as an "extra" example later. It's a lot more difficult than what we ask them to do in WW.  -rac 8/9/2017
           -->
 <!--
@@ -512,7 +510,7 @@
               </md>
             </p>
             </example>
-            <p>It will be more common in our study of algebra that we do not know the value of the variables. In this case, we will have to simplify what we can and leave the variables in our final solution. 
+            <p>It will be more common in our study of algebra that we do not know the value of the variables. In this case, we will have to simplify what we can and leave the variables in our final solution.
             </p>
             <p>One way we can simplify expressions is to combine like terms. Like terms are terms where the variables match exactly (exponents included). Examples of like terms would be
               <m>3xy</m> and
@@ -527,10 +525,10 @@
               <title>Combine Like Terms</title>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 32 pg 23-->
               <p>
-              <md>
-                <mrow>5x-2y -8x+7y \amp\amp\amp \text{Combine like terms \(5x-8x\) and \(-2y +7y\)}</mrow>
-                <mrow>-3x+5y \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+                <md>
+                  <mrow>5x-2y -8x+7y \amp\amp\amp \text{Combine like terms }5x-8x\text{ and }-2y +7y</mrow>
+                  <mrow>-3x+5y \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
             </p>
             </example>
 
@@ -552,15 +550,14 @@
                 </assemblage>
             <p>When we combine like terms we interpret minus signs as part of the term. This means the following term is a negative term, the sign always stays with the term.  We then add the terms together.</p>
 
-            <p>Another simplification technique uses the <term>distributive property</term>. 
+            <p>Another simplification technique uses the <term>distributive property</term>.
             </p>
-
-            <mdn>
-              <mrow xml:id="distributive-property">\text{Distributive Property: }
-                a(b+c)=ab+ac
-              </mrow>
-            </mdn>
-            
+            <p>
+              <mdn>
+                <mrow xml:id="distributive-property">\text{Distributive Property: } a(b+c)=ab+ac
+                </mrow>
+              </mdn>
+            </p>
             <p>Several examples of using the distributive property are given below.</p>
 
             <example>
@@ -593,7 +590,7 @@
 
             <p>It is possible to distribute just a negative through parentheses. If we have a negative in front of parentheses we can think of it like a
               <m>-1</m> in front and distribute the
-              <m>-1</m> through. 
+              <m>-1</m> through.
             </p>
 
             <example>
@@ -636,7 +633,7 @@
 
             <p>In the previous <xref ref="example-simplify" autoname="yes" /> we distributed
               <m>-2</m>, not just
-              <m>2</m>. This is because a negative sign goes with the number after it. Note that <m>-2</m> times <m>-5</m> is positive 
+              <m>2</m>. This is because a negative sign goes with the number after it. Note that <m>-2</m> times <m>-5</m> is positive
               <m>10.</m> Following are more involved examples of distributing and combining like terms.
             </p>
 
@@ -645,24 +642,28 @@
               <p>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 39 pg 24-->
               </p>
-              <md>
-                <mrow>2(5x-8)-6(4x+3) \amp\amp\amp \text{Distribute \(2\) into first parentheses and \(-6\) into second}</mrow>
-                <mrow>10x-16-24x-18 \amp\amp\amp \text{Combine like terms \(10x-24x\) and \(-16-18\)}</mrow>
-                <mrow>-14x-34 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+              <p>
+                <md>
+                  <mrow>2(5x-8)-6(4x+3) \amp\amp\amp \text{Distribute \(2\) into first parentheses and \(-6\) into second}</mrow>
+                  <mrow>10x-16-24x-18 \amp\amp\amp \text{Combine like terms \(10x-24x\) and \(-16-18\)}</mrow>
+                  <mrow>-14x-34 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
             <example>
               <title>Simplify</title>
               <p>
                 <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 40 pg 24-->
               </p>
-              <md>
-                <mrow>4(3x-8)-(2x-7) \amp\amp\amp \text{Negative (subtract) in middle can be thought of as \(-1\)}</mrow>
-                <mrow>4(3x-8)-1(2x-7) \amp\amp\amp \text{Distribute \(4\) into first parentheses and \(-1\) into second}</mrow>
-                <mrow>12x-32-2x+7 \amp\amp\amp \text{Combine like terms \(12x-2x\) and \(-32+7\)}</mrow>
-                <mrow>10x-25 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-              </md>
+              <p>
+                <md>
+                  <mrow>4(3x-8)-(2x-7) \amp\amp\amp \text{Negative (subtract) in middle can be thought of as \(-1\)}</mrow>
+                  <mrow>4(3x-8)-1(2x-7) \amp\amp\amp \text{Distribute \(4\) into first parentheses and \(-1\) into second}</mrow>
+                  <mrow>12x-32-2x+7 \amp\amp\amp \text{Combine like terms \(12x-2x\) and \(-32+7\)}</mrow>
+                  <mrow>10x-25 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+                </md>
+              </p>
             </example>
           </subsection>
         </section>
- 
+

--- a/src/set00_Preliminaries.mbx
+++ b/src/set00_Preliminaries.mbx
@@ -307,7 +307,7 @@
 
           <subsection>
             <title>Operations of Numbers</title>
-            <p>When simplifying an expressions it is important that we perform the operations in the correct order. Consider the following problem done two different ways:</p>
+            <p>When simplifying an expression it is important that we perform the operations in the correct order. Consider the following problem done two different ways:</p>
             <example xml:id="example-warning">
               <title>
                 <alert>WARNING!</alert> 0nly one below solution is correct:
@@ -477,7 +477,7 @@
 
           <subsection>
             <title>Working with Variables</title>
-            <p>we can evaluate an expresson when we know what number each variable in the expression represents. We replace each variable with the equivalent number and simplify what remains using order of operations.</p>
+            <p>We can evaluate an expresson when we know what number each variable in the expression represents. We replace each variable with the equivalent number and simplify what remains using order of operations.</p>
 
             <example xml:id="example-evaluate-expression">
               <title>Evaluate Expression</title>
@@ -494,7 +494,7 @@
 
             <p>Whenever we replace a variable with a number, we put the new number inside parentheses. Notice the
               <m>3</m> and
-              <m>5</m> in the previous <xref ref="example-evaluate-expression" autoname="yes" /> are in parentheses. This is to preserve operations that are sometimes lost inwithout parentheses. Sometimes the parentheses won't make a difference, but it is a good habit to always use them to prevent problems later.
+              <m>5</m> in the previous <xref ref="example-evaluate-expression" autoname="yes" /> are in parentheses. This is to preserve operations that are sometimes lost without parentheses. Sometimes the parentheses won't make a difference, but it is a good habit to always use them to prevent problems later.
             </p>
 
             <example>
@@ -608,7 +608,7 @@
             </p>
             </example>
 
-            <p>We may need to use both the distributive property and combingin like terms to simplify an expression. Order of operations tells us to multiply (distribute) first then add or subtract last (combine like terms). Thus we simplify in two steps, distribute then combine.</p>
+            <p>We may need to use both the distributive property and combining like terms to simplify an expression. Order of operations tells us to multiply (distribute) first then add or subtract last (combine like terms). Thus we simplify in two steps, distribute then combine.</p>
 
             <example>
               <title>Simplify</title>

--- a/src/set1A_Fractions.mbx
+++ b/src/set1A_Fractions.mbx
@@ -1,24 +1,28 @@
 <section xml:id="section-1A-fractions">
   <title>Fractions</title>
   <introduction>
-    <ul>
-      <li>Reduce, add, subtract, multiply, and divide with fractions</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Reduce, add, subtract, multiply, and divide with fractions</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Fractions</title>
     <p>Here we will briefly review operations on fractions.</p>
-    <!--     <figure xml:id="figure-fraction-bar-one-third"> -->
+    <sidebyside>
       <image xml:id="fraction-bar-one-third" width="80%">
-        <latex-image-code><![CDATA[\begin{tikzpicture}[scale=.6] \filldraw[fill=yellow, draw=black] (0,0) rectangle (15,1); \draw (5,0) -- (5,1); \draw (10,0) -- (10,1); \draw[pattern=north west lines, pattern color=black!60!white] (0.1, 0.1) rectangle (4.9, .9); \node at (16, 0.5) {$\dfrac{1}{3}$}; \end{tikzpicture}]]></latex-image-code>
+        <latex-image-code>
+          <![CDATA[\begin{tikzpicture}[scale=.6] \filldraw[fill=yellow, draw=black] (0,0) rectangle (15,1); \draw (5,0) -- (5,1); \draw (10,0) -- (10,1); \draw[pattern=north west lines, pattern color=black!60!white] (0.1, 0.1) rectangle (4.9, .9); \node at (16, 0.5) {$\dfrac{1}{3}$}; \end{tikzpicture}]]>
+        </latex-image-code>
       </image>
-<!--    </figure> -->
+    </sidebyside>
     <p>A fraction can be used to represent parts of a whole. The fraction bar shown above represents the fraction
       <m>\frac{1}{3}</m> since one of three equal parts of the bar is shaded. Any integer can be represented as a fraction, for example
       <m>7</m> can be written as the fraction <m>\frac{7}{1}</m>.
     </p>
-    <p>When working with fractions, we like our final answers to be <term>reduced</term>. This means the numerator and denominator are divided by their greatest common factor, 
-      <term>GCF</term>. 
+    <p>When working with fractions, we like our final answers to be <term>reduced</term>. This means the numerator and denominator are divided by their greatest common factor,
+      <term>GCF</term>.
     </p>
     <example xml:id="reduce-36-over-84">
       <title>Reduce a Fraction</title>
@@ -92,12 +96,14 @@
       <p>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 17 pg 13-->
       </p>
-      <md>
-        <mrow>\dfrac{25}{24} \cdot \dfrac{32}{55} \amp\amp\amp \text{Reduce \(25\) and \(55\) by dividing by \(5\)}</mrow>
-        <mrow>\amp\amp\amp\text{Reduce \(32\) and \(24\) by dividing by \(8\)}</mrow>
-        <mrow>\dfrac{5}{3} \cdot \dfrac{4}{11} \amp\amp\amp \text{Multiply numerators and multiply denominators}</mrow>
-        <mrow>\dfrac{20}{33} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-      </md>
+      <p>
+        <md>
+          <mrow>\dfrac{25}{24} \cdot \dfrac{32}{55} \amp\amp\amp \text{Reduce \(25\) and \(55\) by dividing by \(5\)}</mrow>
+          <mrow>\amp\amp\amp\text{Reduce \(32\) and \(24\) by dividing by \(8\)}</mrow>
+          <mrow>\dfrac{5}{3} \cdot \dfrac{4}{11} \amp\amp\amp \text{Multiply numerators and multiply denominators}</mrow>
+          <mrow>\dfrac{20}{33} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+        </md>
+      </p>
     </example>
 <!--
     <p>It is often easier to write fractions in factored form, and cancel common factors BEFORE multiplying.  Let's try
@@ -215,13 +221,15 @@
     </example>
     <p>To summarize:</p>
     <aside>
-      <term>To add or subtract fractions</term>:
-    <ol>
-      <li>Find their LCD.</li>
-      <li>Build each fraction by multiplying the numerator and denominator with the factor required to get the LCD in the denominator</li>
-      <li>Add/subtract like fractions</li>
-      <li>Reduce your answer</li>
-    </ol>
+      <p>
+        <term>To add or subtract fractions</term>:
+        <ol>
+          <li>Find their LCD.</li>
+          <li>Build each fraction by multiplying the numerator and denominator with the factor required to get the LCD in the denominator</li>
+          <li>Add/subtract like fractions</li>
+          <li>Reduce your answer</li>
+        </ol>
+      </p>
   </aside>
   </subsection>
 </section>

--- a/src/set1B_Percents_and_Estimation.mbx
+++ b/src/set1B_Percents_and_Estimation.mbx
@@ -1,10 +1,12 @@
 <section xml:id="section-1B-percents-and-estimation">
   <title>Percents and Estimation</title>
   <introduction>
-    <ul>
-      <li>Convert between percent and decimal.</li>
-      <li>Estimate sums, differences, products, quotients and percents.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Convert between percent and decimal.</li>
+        <li>Estimate sums, differences, products, quotients and percents.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Percents</title>
@@ -12,13 +14,11 @@
       <term>Percent</term> means "parts per hundred."  For example, the figure below represents
       <m>23\%</m>.
     </p>
-    <p>
-      <!--     <figure xml:id="figure-decimal-square-labeled"> -->
-        <image xml:id="decimal-square-labeled" width="60%">
-          <latex-image-code><![CDATA[\begin{tikzpicture}[scale=.5] \fill[fill=M101_green!50!white] (0,0) rectangle (1,10); \fill[fill=M101_green!50!white] (1,0) rectangle (2,10); \fill[fill=M101_green!50!white] (2,0) rectangle (3,3); \draw[step=1cm,black, thick] (0,0) grid (10,10); \node at (11, 5) {$23\%$}; \end{tikzpicture}]]></latex-image-code>
-        </image>
-      <!-- </figure> -->
-    </p>
+    <sidebyside>
+      <image xml:id="decimal-square-labeled" width="60%">
+        <latex-image-code><![CDATA[\begin{tikzpicture}[scale=.5] \fill[fill=M101_green!50!white] (0,0) rectangle (1,10); \fill[fill=M101_green!50!white] (1,0) rectangle (2,10); \fill[fill=M101_green!50!white] (2,0) rectangle (3,3); \draw[step=1cm,black, thick] (0,0) grid (10,10); \node at (11, 5) {$23\%$}; \end{tikzpicture}]]></latex-image-code>
+      </image>
+    </sidebyside>
     <p>The large square is partitioned into
       <m>10\times 10 = 100</m> equal parts.  We have shaded
       <m>23</m> of the
@@ -57,7 +57,7 @@
     <assemblage>
       <title>WeBWorK: Entering Decimals</title>
       <p>Type
-              <c>.375</c> for <m>.375</m> 
+              <c>.375</c> for <m>.375</m>
       </p>
     </assemblage>
     <p>This last example motivates the following simple rule. To change a percent to a decimal, drop the percent symbol and move the decimal point two places to the left.</p>

--- a/src/set1C_Exponents_and_Scientific_Notation.mbx
+++ b/src/set1C_Exponents_and_Scientific_Notation.mbx
@@ -104,7 +104,7 @@
           \frac{a^m}{ a^n} =a^{m-n}
         </mrow>
       </mdn>
-      
+
       <p>The quotient rule of exponents may be used to divide powers by subtracting exponents on like bases. This is shown in the following examples:</p>
       <example>
         <title>Quotient Rule of Exponents</title>
@@ -209,7 +209,7 @@
           \left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}
         </mrow>
       </mdn>
-      
+
       <p>We may need to use several rules to simplify an expression. This is shown in the following examples:</p>
       <example>
         <title>Simplify Exponents</title>
@@ -243,7 +243,7 @@
         <m>5</m> by
         <m>3</m>, rather we multiply
         <m>5</m> three times,
-        <m>5 \cdot 5 \cdot 5 = 125</m>. 
+        <m>5 \cdot 5 \cdot 5 = 125</m>.
       </p>
       <example>
         <title>Simplify Exponents</title>
@@ -256,7 +256,7 @@
         </md>
       </p>
       </example>
-      <p>In the previous example we did not multipy 
+      <p>In the previous example we did not multipy
         <m>4</m> by the exponent <m>3</m> to get
         <m>12</m>: this would have been incorrect. Never multiply a base by the exponent.
       </p>
@@ -292,9 +292,9 @@
             </row>
           </tabular>
 <!--        </table>  -->
-          
+
       <p>Generally, simplifying an expression requires a combination of properties, and deciding which property to use first may be confusing. However, the order of operations
-       <!-- <term>PEMDAS</term> (see <xref ref="section-00-preliminaries" autoname="yes" /> ) --> 
+       <!-- <term>PEMDAS</term> (see <xref ref="section-00-preliminaries" autoname="yes" /> ) -->
        always applies and can be your guide. You should simplify inside any parentheses first, then simplify any exponents (using power rules), and finally simplify any multiplication or division (using product and quotient rules).
       </p>
       <example>
@@ -481,33 +481,32 @@
     </assemblage>
 
       <p>We now have the following nine properties of exponents.</p>
-
-<!--      <table>  -->
+      <sidebyside>
         <tabular top="major" halign="center">
-            <col halign="center" />
-            <col halign="center" />
-            <col halign="center" />
-            <!--  -->
-            <row bottom="minor">
-              <cell colspan="3">Properties of Exponents</cell>
-            </row>
-            <row>
-              <cell><m>a^m a^n=a^{m+n}</m></cell>
-              <cell><m>(ab)^m=a^m b^m</m></cell>
-              <cell><m>a^{-m}=\dfrac{1}{a^m}</m></cell>
-            </row>
-            <row>
-              <cell><m>\frac{a^m}{a^n}=a^{m-n}</m></cell>
-              <cell><m>\left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}</m></cell>
-              <cell><m>\dfrac{1}{a^{-m}}= a^m</m></cell>
-            </row>
-            <row>
-              <cell><m>(a^m)^n=a^{mn}</m></cell>
-              <cell><m>a^0=1</m></cell>
-              <cell><m>\left( \dfrac{a}{b}\right)^{-m}=\dfrac{b^m}{a^m}</m></cell>
-            </row>
-          </tabular>
- <!--       </table>  -->
+          <col halign="center" />
+          <col halign="center" />
+          <col halign="center" />
+          <!--  -->
+          <row bottom="minor">
+            <cell colspan="3">Properties of Exponents</cell>
+          </row>
+          <row>
+            <cell><m>a^m a^n=a^{m+n}</m></cell>
+            <cell><m>(ab)^m=a^m b^m</m></cell>
+            <cell><m>a^{-m}=\dfrac{1}{a^m}</m></cell>
+          </row>
+          <row>
+            <cell><m>\frac{a^m}{a^n}=a^{m-n}</m></cell>
+            <cell><m>\left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}</m></cell>
+            <cell><m>\dfrac{1}{a^{-m}}= a^m</m></cell>
+          </row>
+          <row>
+            <cell><m>(a^m)^n=a^{mn}</m></cell>
+            <cell><m>a^0=1</m></cell>
+            <cell><m>\left( \dfrac{a}{b}\right)^{-m}=\dfrac{b^m}{a^m}</m></cell>
+          </row>
+        </tabular>
+      </sidebyside>
     </subsection>
     <subsection>
       <title>Scientific Notation</title>
@@ -531,12 +530,14 @@
       <example>
         <title>Convert Standard to Scientific: Large number</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 221 pg 188-->
-        <md>
-          <mrow>\text{Convert \(14,200\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
-          <mrow>1.42 \amp\amp\amp \text{Exponent is how many times decimal moved, \(4\)}</mrow>
-          <mrow>\times 10^4 \amp\amp\amp \text{Positive exponent, standard notation is big}</mrow>
-          <mrow>1.42 \times 10^4 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(14,200\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
+            <mrow>1.42 \amp\amp\amp \text{Exponent is how many times decimal moved, \(4\)}</mrow>
+            <mrow>\times 10^4 \amp\amp\amp \text{Positive exponent, standard notation is big}</mrow>
+            <mrow>1.42 \times 10^4 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>When scientific notation is used to represent small numbers, the format requires the number be rewritten as a "bigger" value:
       <m>0.0021</m> must be written as
@@ -550,19 +551,21 @@
       <m>\frac{1}{10}</m> and negative exponents allow us to write the fraction as a power of 10:
       <m>10^{-1} = \frac{1}{10}.</m> To finish the conversion of
       <m>0.0021</m> to scientific notation:
-      <m>0.0021 = 2.1 \times 10^{-3}.</m> 
+      <m>0.0021 = 2.1 \times 10^{-3}.</m>
       </p>
       <example>
         <title>Convert Standard to Scientific: Small number</title>
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 222 pg 188-->
         </p>
-        <md>
-          <mrow>\text{Convert \(0.0042\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
-          <mrow>4.2 \amp\amp\amp \text{Exponent is how many times decimal moved, \(3\)}</mrow>
-          <mrow>\times 10^{-3} \amp\amp\amp \text{Small standard number means a negative exponent}</mrow>
-          <mrow>4.2 \times 10^{-3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(0.0042\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
+            <mrow>4.2 \amp\amp\amp \text{Exponent is how many times decimal moved, \(3\)}</mrow>
+            <mrow>\times 10^{-3} \amp\amp\amp \text{Small standard number means a negative exponent}</mrow>
+            <mrow>4.2 \times 10^{-3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>To decide which direction to move the decimal (left or right) we simply need to remember that positive exponents mean we have a big number (bigger than ten) in standard notation, and negative exponents mean we have a small number (less than one) in standard notation. The negative exponent simply informs us that we are dealing with a small number.</p>
       <assemblage>
@@ -577,7 +580,7 @@
         </p>
         <p>For exponents with two or more digits, enter
           <c>7.24 x 10^21</c> for
-          <m>47.24 \times 10^{21}.</m> 
+          <m>47.24 \times 10^{21}.</m>
         </p>
       </assemblage>
       <example>
@@ -585,20 +588,24 @@
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 223 pg 189-->
         </p>
-        <md>
-          <mrow>\text{Convert \(3.21\times 10^5\) to standard notation} \amp\amp\amp \text{Positive exponent: Move decimal right \(5\) places}</mrow>
-          <mrow>321,000 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(3.21\times 10^5\) to standard notation} \amp\amp\amp \text{Positive exponent: Move decimal right \(5\) places}</mrow>
+            <mrow>321,000 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Convert Scientific to Standard</title>
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 224 pg 189-->
         </p>
-        <md>
-          <mrow>\text{Convert \(7.4\times 10^{-3}\) to standard notation} \amp\amp\amp \text{Negative exponent: Move decimal left \(3\) places}</mrow>
-          <mrow>0.0074 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(7.4\times 10^{-3}\) to standard notation} \amp\amp\amp \text{Negative exponent: Move decimal left \(3\) places}</mrow>
+            <mrow>0.0074 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>When you use a calculator or computer, sometimes scientific notation will be displayed a little differently.  The number will look like <c>2.341 E03</c> or <c>2.341 e03</c>.  In this case, the <c>E03</c> is short for "<m>\times 10^3</m>" and the number is <m>2.341 \times 10^3</m>.</p>
       <example>
@@ -606,11 +613,13 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>\text{Convert } 5.915 E-12  \text{ to scientific notation} \amp\amp\amp \text{Exponent on \(10\) is \(-12\)}</mrow>
-          <mrow>5.915 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
-      </example>      
+        <p>
+          <md>
+            <mrow>\text{Convert } 5.915 E-12  \text{ to scientific notation} \amp\amp\amp \text{Exponent on \(10\) is \(-12\)}</mrow>
+            <mrow>5.915 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
+      </example>
 
     </subsection>
     <subsection>
@@ -623,36 +632,42 @@
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 225 pg 189-->
         </p>
-        <md>
-          <mrow>(2.1\times 10^{-7})(3.7\times 10^{5}) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>(2.1)(3.7)=7.77 \amp\amp\amp \text{Multiply front numbers}</mrow>
-          <mrow>10^{-7} 10^5=10^{-2} \amp\amp\amp \text{Use product rule on \(10\)'s and add exponents}</mrow>
-          <mrow>7.77 \times 10^{-2} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>(2.1\times 10^{-7})(3.7\times 10^{5}) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>(2.1)(3.7)=7.77 \amp\amp\amp \text{Multiply front numbers}</mrow>
+            <mrow>10^{-7} 10^5=10^{-2} \amp\amp\amp \text{Use product rule on \(10\)'s and add exponents}</mrow>
+            <mrow>7.77 \times 10^{-2} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Division with Scientific Notation</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 226 pg 189-->
-        <md>
-          <mrow>\dfrac{4.96\times 10^{4}}{3.1\times 10^{-3}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>\dfrac{4.96}{3.1}=1.6 \amp\amp\amp \text{Divide front numbers}</mrow>
-          <mrow>\dfrac{10^{4}}{10^{-3}}=10^{7} \amp\amp\amp \text{Use quotient rule to subtract exponents,}</mrow>
-          <mrow>\text{ }\amp\amp\amp \text{be careful with negatives!}</mrow>
-          <mrow>\text{ }\amp\amp\amp 4-(-3)=4+3=7</mrow>
-          <mrow>1.6 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\dfrac{4.96\times 10^{4}}{3.1\times 10^{-3}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>\dfrac{4.96}{3.1}=1.6 \amp\amp\amp \text{Divide front numbers}</mrow>
+            <mrow>\dfrac{10^{4}}{10^{-3}}=10^{7} \amp\amp\amp \text{Use quotient rule to subtract exponents,}</mrow>
+            <mrow>\text{ }\amp\amp\amp \text{be careful with negatives!}</mrow>
+            <mrow>\text{ }\amp\amp\amp 4-(-3)=4+3=7</mrow>
+            <mrow>1.6 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Powers with Scientific Notation</title>
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 227 pg 190-->
         </p>
-        <md>
-          <mrow>(1.8\times 10^{-4})^3 \amp\amp\amp \text{Use power rule to deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>(1.8)^3=5.832 \amp\amp\amp \text{Evaluate \((1.8)^3\)}</mrow>
-          <mrow>(10^{-4})^3=10^{-12} \amp\amp\amp \text{Multiply exponents}</mrow>
-          <mrow>5.832 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>(1.8\times 10^{-4})^3 \amp\amp\amp \text{Use power rule to deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>(1.8)^3=5.832 \amp\amp\amp \text{Evaluate \((1.8)^3\)}</mrow>
+            <mrow>(10^{-4})^3=10^{-12} \amp\amp\amp \text{Multiply exponents}</mrow>
+            <mrow>5.832 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>After computation, if the front number is greater than <m>10,</m> we convert the front number into scientific notation and then simplify the expression.
       </p>
@@ -661,28 +676,32 @@
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 228 pg 190-->
         </p>
-        <md>
-          <mrow>(4.7\times 10^{-3})(6.1\times 10^9) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>(4.7)(6.1)=28.67 \amp\amp\amp \text{Multiply the front numbers}</mrow>
-          <mrow>2.867\times 10^1 \amp\amp\amp \text{Convert the front to scientific notation}</mrow>
-          <mrow>10^1 10^{-3} 10^9=10^{7} \amp\amp\amp \text{Use the Product Rule: add exponents include the \(10^1\) from front conversion}
-          </mrow>
-          <mrow>2.867 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>(4.7\times 10^{-3})(6.1\times 10^9) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>(4.7)(6.1)=28.67 \amp\amp\amp \text{Multiply the front numbers}</mrow>
+            <mrow>2.867\times 10^1 \amp\amp\amp \text{Convert the front to scientific notation}</mrow>
+            <mrow>10^1 10^{-3} 10^9=10^{7} \amp\amp\amp \text{Use the Product Rule: add exponents include the \(10^1\) from front conversion}
+            </mrow>
+            <mrow>2.867 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Division with Scientific Notation</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 229 pg 190-->
-        <md>
-          <mrow>\dfrac{2.014\times 10^{-3}}{3.8\times 10^{-7}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>\dfrac{2.014}{3.8}=0.53 \amp\amp\amp \text{Divide numbers}</mrow>
-          <mrow>0.53=5.3\times 10^{-1} \amp\amp\amp \text{Convert this number into scientific notation}</mrow>
-          <mrow>\dfrac{10^{-1} 10^{-3}}{ 10^{-7}}=10^{3} \amp\amp\amp \text{Use product and quotient rule,}</mrow>
-          <mrow>\text{ }\amp\amp\amp \text{using \(10^{-1}\) from the conversion}</mrow>
-          <mrow>\text{ }\amp\amp\amp \text{Be careful with signs:}</mrow>
-          <mrow>\text{ }\amp\amp\amp (-1)+(-3)-(-7)=(-1)+(-3)+7=7-4=3</mrow>
-          <mrow>5.3 \times 10^{3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\dfrac{2.014\times 10^{-3}}{3.8\times 10^{-7}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>\dfrac{2.014}{3.8}=0.53 \amp\amp\amp \text{Divide numbers}</mrow>
+            <mrow>0.53=5.3\times 10^{-1} \amp\amp\amp \text{Convert this number into scientific notation}</mrow>
+            <mrow>\dfrac{10^{-1} 10^{-3}}{ 10^{-7}}=10^{3} \amp\amp\amp \text{Use product and quotient rule,}</mrow>
+            <mrow>\text{ }\amp\amp\amp \text{using \(10^{-1}\) from the conversion}</mrow>
+            <mrow>\text{ }\amp\amp\amp \text{Be careful with signs:}</mrow>
+            <mrow>\text{ }\amp\amp\amp (-1)+(-3)-(-7)=(-1)+(-3)+7=7-4=3</mrow>
+            <mrow>5.3 \times 10^{3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
 
     </subsection>
@@ -694,12 +713,14 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Write both numbers in standard notation}</mrow>
-          <mrow>2,360,000 + 9,700,000 \amp\amp\amp \text{Add numbers}</mrow>
-          <mrow>12,060,000 \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Write both numbers in standard notation}</mrow>
+            <mrow>2,360,000 + 9,700,000 \amp\amp\amp \text{Add numbers}</mrow>
+            <mrow>12,060,000 \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>Because both numbers were times
         <m>10^6</m>, we also could have combined like terms involving
@@ -710,26 +731,30 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Combine like terms involving \(10^6\)}</mrow>
-          <mrow>(2.36+ 9.7)\times 10^{6} \amp\amp\amp \text{Add front numbers}</mrow>
-          <mrow>(12.06)\times 10^{6} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>(1.206 \times 10^1)\times 10^{6} \amp\amp\amp \text{Add exponents: \(10^1\times 10^6 = 10^{1+6}\)}</mrow>
-          <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Combine like terms involving \(10^6\)}</mrow>
+            <mrow>(2.36+ 9.7)\times 10^{6} \amp\amp\amp \text{Add front numbers}</mrow>
+            <mrow>(12.06)\times 10^{6} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>(1.206 \times 10^1)\times 10^{6} \amp\amp\amp \text{Add exponents: \(10^1\times 10^6 = 10^{1+6}\)}</mrow>
+            <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>Subtraction of numbers written using scientific notation is similar.</p>
       <example>
         <title>Subtraction with Scientific Notation</title>
         <!-- Our own-->
         <p>Subtract and write the result using scientific notation.</p>
-        <md>
-          <mrow>4.77\times 10^{-7}- 4.86\times 10^{-7} \amp\amp\amp \text{Combine like terms involving \(10^{-7}\)}</mrow>
-          <mrow>(4.77-4.86)\times 10^{-7} \amp\amp\amp \text{Subtract front numbers}</mrow>
-          <mrow>(-0.09)\times 10^{-7} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>(-9.0 \times 10^{-2})\times 10^{-7} \amp\amp\amp \text{Add exponents: \(10^{-2}\times 10^{-7} = 10^{-2-7}\)}</mrow>
-          <mrow>-9.0 \times 10^{-9} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>4.77\times 10^{-7}- 4.86\times 10^{-7} \amp\amp\amp \text{Combine like terms involving \(10^{-7}\)}</mrow>
+            <mrow>(4.77-4.86)\times 10^{-7} \amp\amp\amp \text{Subtract front numbers}</mrow>
+            <mrow>(-0.09)\times 10^{-7} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>(-9.0 \times 10^{-2})\times 10^{-7} \amp\amp\amp \text{Add exponents: \(10^{-2}\times 10^{-7} = 10^{-2-7}\)}</mrow>
+            <mrow>-9.0 \times 10^{-9} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>If the scientific numbers do not both involve the same power of
         <m>10</m>, we adjust one of the numbers to match the power of
@@ -740,15 +765,17 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>8.93\times 10^{13}- 9.26\times 10^{14} \amp\amp\amp \text{Rewrite \(10^{14}\) as \(10^1\times 10^{13}\) to match the other power of \(13\)}</mrow>
-          <mrow>8.93\times 10^{13}- 9.26\times 10^1 \times 10^{13} \amp\amp\amp \text{Multiply \(-9.26\times 10^{1}\)}</mrow>
-          <mrow>8.93\times 10^{13}- 92.6\times 10^{13} \amp\amp\amp \text{Combine like terms involving \(10^{13}\)}</mrow>
-          <mrow>(8.93-92.6)\times 10^{13} \amp\amp\amp \text{Subtract front numbers}</mrow>
-          <mrow>(-83.67)\times 10^{13} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>(-8.367 \times 10^{1})\times 10^{13} \amp\amp\amp \text{Add exponents: \(10^{1}\times 10^{13} = 10^{1+13}\)}</mrow>
-          <mrow>-8.367 \times 10^{14} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>8.93\times 10^{13}- 9.26\times 10^{14} \amp\amp\amp \text{Rewrite \(10^{14}\) as \(10^1\times 10^{13}\) to match the other power of \(13\)}</mrow>
+            <mrow>8.93\times 10^{13}- 9.26\times 10^1 \times 10^{13} \amp\amp\amp \text{Multiply \(-9.26\times 10^{1}\)}</mrow>
+            <mrow>8.93\times 10^{13}- 92.6\times 10^{13} \amp\amp\amp \text{Combine like terms involving \(10^{13}\)}</mrow>
+            <mrow>(8.93-92.6)\times 10^{13} \amp\amp\amp \text{Subtract front numbers}</mrow>
+            <mrow>(-83.67)\times 10^{13} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>(-8.367 \times 10^{1})\times 10^{13} \amp\amp\amp \text{Add exponents: \(10^{1}\times 10^{13} = 10^{1+13}\)}</mrow>
+            <mrow>-8.367 \times 10^{14} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
     </subsection>
   </section>

--- a/src/set1C_Exponents_and_Scientific_Notation.mbx
+++ b/src/set1C_Exponents_and_Scientific_Notation.mbx
@@ -1,12 +1,14 @@
 <section xml:id="section-1C-exponents-and-scientific-notation">
   <title>Exponents and Scientific Notation</title>
   <introduction>
-    <ul>
-      <li>Simplify expressions using the properties of exponents.</li>
-      <li>Convert between standard and scientific notation.</li>
-      <li>Multiply and divide expressions using scientific notation and exponent properties.</li>
-      <li>Add and subtract expressions using scientific notation and exponent properties.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Simplify expressions using the properties of exponents.</li>
+        <li>Convert between standard and scientific notation.</li>
+        <li>Multiply and divide expressions using scientific notation and exponent properties.</li>
+        <li>Add and subtract expressions using scientific notation and exponent properties.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Exponent Properties</title>
@@ -54,11 +56,13 @@
         <m>a^3 a^2=a^{3+2}=a^5</m>. This is known as the
         <term>product rule of exponents</term>:
       </p>
-      <mdn>
-        <mrow xml:id="exponents-product-rule">\text{Product Rule of Exponents: }
-          a^m a^n=a^{m+n}
-        </mrow>
-      </mdn>
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-product-rule">\text{Product Rule of Exponents: }
+            a^m a^n=a^{m+n}
+          </mrow>
+        </mdn>
+      </p>
 
       <p>The product rule of exponents can be used to multiply powers with the same base. This is shown in the following examples:</p>
 
@@ -115,21 +119,24 @@
         <m>\dfrac{a^5}{ a^2} = a^{5-2}= a^3</m>. This is known as the
         <term>quotient rule of exponents</term>.
       </p>
-      <mdn>
-        <mrow xml:id="exponents-quotient-rule"> \text{Quotient Rule of Exponents: }
-          \frac{a^m}{ a^n} =a^{m-n}
-        </mrow>
-      </mdn>
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-quotient-rule"> \text{Quotient Rule of Exponents: }
+            \frac{a^m}{ a^n} =a^{m-n}
+          </mrow>
+        </mdn>
+      </p>
 
       <p>The quotient rule of exponents may be used to divide powers by subtracting exponents on like bases. This is shown in the following examples:</p>
       <example>
         <title>Quotient Rule of Exponents</title>
-        <p>Simplify:</p>
-        <md>
-          <mrow>\dfrac{7^5 x^8}{7^4 x^3} \amp\amp\amp \text{Subtract the exponents on like bases, \(5-4 = 1\) and \(8-3=5\)}</mrow>
-          <mrow>7^1x^5 \amp\amp\amp \text{Note that \(7^1 = 7\) since there is only one \(7\) to multiply.}</mrow>
-          <mrow>7x^5 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>Simplify:
+          <md>
+            <mrow>\dfrac{7^5 x^8}{7^4 x^3} \amp\amp\amp \text{Subtract the exponents on like bases, \(5-4 = 1\) and \(8-3=5\)}</mrow>
+            <mrow>7^1x^5 \amp\amp\amp \text{Note that \(7^1 = 7\) since there is only one \(7\) to multiply.}</mrow>
+            <mrow>7x^5 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <!--Remove this example <example> <title>Quotient Rule of Exponents</title> <p> <!** Cite Beginning and Intermediate Algebra by Tyler Wallace Example 201 pg 178**> </p> <md> <mrow>\dfrac{5a^3 b^5 c^2}{2ab^3 c} \amp\amp\amp \text{Subtract exponents on \(a, b\) and \(c\)}</mrow> <mrow>\frac{5}{2} a^2 b^2 c \amp\amp\amp \text{Our Solution}</mrow> </md> </example> -->
       <p>A power may itself be raised to a second exponent.</p>
@@ -150,13 +157,13 @@
         <m>(a^2)^3 = a^{2\cdot 3} = a^6.</m> This is known as the
         <term>power of a power rule of exponents</term>
       </p>
-
-      <mdn>
-        <mrow xml:id="exponents-power-of-a-power-rule"> \text{Power of a Power Rule of Exponents: }
-          (a^m)^n=a^{mn}
-        </mrow>
-      </mdn>
-
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-power-of-a-power-rule"> \text{Power of a Power Rule of Exponents: }
+            (a^m)^n=a^{mn}
+          </mrow>
+        </mdn>
+      </p>
       <p>There are two more useful properties of exponents.</p>
       <example>
         <title>Powers of Products</title>
@@ -174,18 +181,18 @@
         <m>(ab)^3 = a^3b^3</m>. This is known as the
         <term>power of a product rule of exponents</term>:
       </p>
-
-      <mdn>
-        <mrow xml:id="exponents-power-of-a-product-rule"> \text{Power of a Product Rule of Exponents: }
-          (ab)^m=a^m b^m
-        </mrow>
-      </mdn>
-
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-power-of-a-product-rule"> \text{Power of a Product Rule of Exponents: }
+            (ab)^m=a^m b^m
+          </mrow>
+        </mdn>
+      </p>
       <p>It is important that we only use the power of a product rule with multiplication inside parentheses. This property does NOT work if there is addition or subtraction inside the parentheses.</p>
       <aside>
-      <alert>WARNING:</alert>
-      <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Warning 204 pg 179-->
       <p>
+        <alert>WARNING:</alert>
+        <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Warning 204 pg 179-->
         <md>
           <mrow>(a+b)^n\ne a^n+b^n \amp\amp\amp \text{These are NOT equal if \(n\ne 1\), beware of this error!}</mrow>
         </md>
@@ -219,12 +226,13 @@
         <m>\left(\frac{a}{b} \right)^3=\frac{a^3}{b^3}</m>. This is known as the
         <term>power of a quotient rule of exponents</term>:
       </p>
-
-      <mdn>
-        <mrow xml:id="exponents-power-of-a-quotient-rule"> \text{Power of a Quotient Rule of Exponents: }
-          \left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}
-        </mrow>
-      </mdn>
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-power-of-a-quotient-rule"> \text{Power of a Quotient Rule of Exponents: }
+            \left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}
+          </mrow>
+        </mdn>
+      </p>
 
       <p>We may need to use several rules to simplify an expression. This is shown in the following examples:</p>
       <example>
@@ -232,7 +240,7 @@
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 206 pg 179-->
         <p>Simplify.
         <md>
-          <mrow>(x^3y)^4 \amp\amp\amp \text{Raise each factor to the <m>4^{th}</m> power, multiply exponents}</mrow>
+          <mrow>(x^3y)^4 \amp\amp\amp \text{Raise each factor to the }4^{\mathrm{th}}\text{ power, multiply exponents}</mrow>
           <mrow>x^{12} y^4 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
       </p>
@@ -249,7 +257,7 @@
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 207 pg 180-->
         <p>Simplify.
         <md>
-          <mrow>\left(\dfrac{a^3 b}{c^4 d^5} \right)^2 \amp\amp\amp \text{Raise each factor to the <m>2^{nd}</m> power, multiply exponents}</mrow>
+          <mrow>\left(\dfrac{a^3 b}{c^4 d^5} \right)^2 \amp\amp\amp \text{Raise each factor to the }2^{\mathrm{nd}}\text{ power, multiply exponents}</mrow>
           <mrow>\dfrac{a^6 b^2}{c^8d^{10}} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
       </p>
@@ -266,7 +274,7 @@
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 208 pg 180-->
         <p>Simplify.
         <md>
-          <mrow>(4x^2 y^5)^3 \amp\amp\amp \text{Raise each factor to the <m>3^{rd}</m> power, multiply exponents}</mrow>
+          <mrow>(4x^2 y^5)^3 \amp\amp\amp \text{Raise each factor to the }3^{\mathrm{rd}}\text{ power, multiply exponents}</mrow>
           <mrow>4^3 x^6 y^{15} \amp\amp\amp \text{Evaluate \(4^3=4\cdot 4\cdot 4\)}</mrow>
           <mrow>64x^6 y^{15} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
@@ -277,8 +285,7 @@
         <m>12</m>: this would have been incorrect. Never multiply a base by the exponent.
       </p>
       <p>The exponent properties are summarized in the following table:</p>
-
-<!--      <table>  -->
+      <sidebyside>
         <tabular top="major" halign="center">
             <col halign="left" />
             <col halign="right" />
@@ -307,8 +314,7 @@
               <cell><m>\left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}</m><xref ref="exponents-power-of-a-quotient-rule" /></cell>
             </row>
           </tabular>
-<!--        </table>  -->
-
+        </sidebyside>
       <p>Generally, simplifying an expression requires a combination of properties, and deciding which property to use first may be confusing. However, the order of operations
        <!-- <term>PEMDAS</term> (see <xref ref="section-00-preliminaries" autoname="yes" /> ) -->
        always applies and can be your guide. You should simplify inside any parentheses first, then simplify any exponents (using power rules), and finally simplify any multiplication or division (using product and quotient rules).
@@ -437,9 +443,8 @@
       </p>
       </example>
       <p>Following are the rules of negative exponents:</p>
-
-<!--      <table>  -->
-        <tabular top="major" halign="center">
+        <sidebyside>
+          <tabular top="major" halign="center">
             <col halign="center" />
             <!--  -->
             <row bottom="minor" halign="center">
@@ -458,8 +463,7 @@
               <cell><m>\left( \dfrac{a}{b}\right)^{-m}=\dfrac{b^m}{a^m}</m></cell>
             </row>
           </tabular>
- <!--       </table>  -->
-
+        </sidebyside>
       <p>The rules of exponents apply to negative exponents as well as positive exponents. It is convenient to keep the negative exponents until the end of the problem and then "move them around" to their correct location (numerator or denominator). It is important to be very careful of rules for adding, subtracting, and multiplying with negatives.</p>
       <example>
         <title>Negative Exponents</title>

--- a/src/set1C_Exponents_and_Scientific_Notation.mbx
+++ b/src/set1C_Exponents_and_Scientific_Notation.mbx
@@ -82,6 +82,22 @@
         </md>
       </p>
       </example>
+      <p>
+      When multiplication and addition/subtraction are used in the same expression, you need to keep track of which rule to use.
+      </p>
+      <example>
+        <title>Combine like terms</title>
+          <!--Our own -rac-->
+        <p>Write the expression without parenthesis.  Combine like terms.
+        <md>
+          <mrow>2t(3t+1)-4(5-t^2) \amp\amp\amp \text{Distribute the } 2t \text{ and } -4</mrow>
+          <mrow>2t \cdot 3t+2t \cdot 1 - 4\cdot 5- 4 \cdot -t^2 \amp\amp\amp \text{Simplify }</mrow> 
+           <mrow>6t^2+2t-20+4t^2 \amp\amp\amp \text{Combine like terms }</mrow>                   
+          <mrow>10t^2+2t-20 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+        </md>
+      </p>
+      </example>
+
       <p>Next, we consider what happens when we divide with exponents.</p>
       <example>
         <title>Division with Exponents</title>
@@ -305,7 +321,7 @@
           <mrow>(4x^3 y \cdot 5x^4 y^2)^3 \amp\amp\amp \underline{P}EMDAS\text{ First inside Parentheses:}</mrow>
           <mrow>\amp\amp\amp\text{Multiply constants \(4\cdot 5 = 20\),}\</mrow>
           <mrow>\amp\amp\amp\text{Apply Product Rule: add exponents}</mrow>
-          <mrow>(20x^7 y^3)^3 \amp\amp\amp P\underline{E}MDAS\text{: Next Eponents:}</mrow>
+          <mrow>(20x^7 y^3)^3 \amp\amp\amp P\underline{E}MDAS\text{: Next Exponents:}</mrow>
           <mrow>\amp\amp\amp\text{Apply Power of a Product Rule: multiply exponents}
           </mrow>
           <mrow>20^3 x^{21} y^9 \amp\amp\amp \text{Evaluate \(20^3\)}</mrow>
@@ -577,7 +593,7 @@
         </p>
         <p>For exponents with two or more digits, enter
           <c>7.24 x 10^21</c> for
-          <m>47.24 \times 10^{21}.</m> 
+          <m>7.24 \times 10^{21}.</m> 
         </p>
       </assemblage>
       <example>

--- a/src/set1C_Exponents_and_Scientific_Notation.mbx
+++ b/src/set1C_Exponents_and_Scientific_Notation.mbx
@@ -1,12 +1,14 @@
 <section xml:id="section-1C-exponents-and-scientific-notation">
   <title>Exponents and Scientific Notation</title>
   <introduction>
-    <ul>
-      <li>Simplify expressions using the properties of exponents.</li>
-      <li>Convert between standard and scientific notation.</li>
-      <li>Multiply and divide expressions using scientific notation and exponent properties.</li>
-      <li>Add and subtract expressions using scientific notation and exponent properties.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Simplify expressions using the properties of exponents.</li>
+        <li>Convert between standard and scientific notation.</li>
+        <li>Multiply and divide expressions using scientific notation and exponent properties.</li>
+        <li>Add and subtract expressions using scientific notation and exponent properties.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Exponent Properties</title>
@@ -54,11 +56,13 @@
         <m>a^3 a^2=a^{3+2}=a^5</m>. This is known as the
         <term>product rule of exponents</term>:
       </p>
-      <mdn>
-        <mrow xml:id="exponents-product-rule">\text{Product Rule of Exponents: }
-          a^m a^n=a^{m+n}
-        </mrow>
-      </mdn>
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-product-rule">\text{Product Rule of Exponents: }
+            a^m a^n=a^{m+n}
+          </mrow>
+        </mdn>
+      </p>
 
       <p>The product rule of exponents can be used to multiply powers with the same base. This is shown in the following examples:</p>
 
@@ -99,21 +103,24 @@
         <m>\dfrac{a^5}{ a^2} = a^{5-2}= a^3</m>. This is known as the
         <term>quotient rule of exponents</term>.
       </p>
-      <mdn>
-        <mrow xml:id="exponents-quotient-rule"> \text{Quotient Rule of Exponents: }
-          \frac{a^m}{ a^n} =a^{m-n}
-        </mrow>
-      </mdn>
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-quotient-rule"> \text{Quotient Rule of Exponents: }
+            \frac{a^m}{ a^n} =a^{m-n}
+          </mrow>
+        </mdn>
+      </p>
 
       <p>The quotient rule of exponents may be used to divide powers by subtracting exponents on like bases. This is shown in the following examples:</p>
       <example>
         <title>Quotient Rule of Exponents</title>
-        <p>Simplify:</p>
-        <md>
-          <mrow>\dfrac{7^5 x^8}{7^4 x^3} \amp\amp\amp \text{Subtract the exponents on like bases, \(5-4 = 1\) and \(8-3=5\)}</mrow>
-          <mrow>7^1x^5 \amp\amp\amp \text{Note that \(7^1 = 7\) since there is only one \(7\) to multiply.}</mrow>
-          <mrow>7x^5 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>Simplify:
+          <md>
+            <mrow>\dfrac{7^5 x^8}{7^4 x^3} \amp\amp\amp \text{Subtract the exponents on like bases, \(5-4 = 1\) and \(8-3=5\)}</mrow>
+            <mrow>7^1x^5 \amp\amp\amp \text{Note that \(7^1 = 7\) since there is only one \(7\) to multiply.}</mrow>
+            <mrow>7x^5 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <!--Remove this example <example> <title>Quotient Rule of Exponents</title> <p> <!** Cite Beginning and Intermediate Algebra by Tyler Wallace Example 201 pg 178**> </p> <md> <mrow>\dfrac{5a^3 b^5 c^2}{2ab^3 c} \amp\amp\amp \text{Subtract exponents on \(a, b\) and \(c\)}</mrow> <mrow>\frac{5}{2} a^2 b^2 c \amp\amp\amp \text{Our Solution}</mrow> </md> </example> -->
       <p>A power may itself be raised to a second exponent.</p>
@@ -134,13 +141,13 @@
         <m>(a^2)^3 = a^{2\cdot 3} = a^6.</m> This is known as the
         <term>power of a power rule of exponents</term>
       </p>
-
-      <mdn>
-        <mrow xml:id="exponents-power-of-a-power-rule"> \text{Power of a Power Rule of Exponents: }
-          (a^m)^n=a^{mn}
-        </mrow>
-      </mdn>
-
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-power-of-a-power-rule"> \text{Power of a Power Rule of Exponents: }
+            (a^m)^n=a^{mn}
+          </mrow>
+        </mdn>
+      </p>
       <p>There are two more useful properties of exponents.</p>
       <example>
         <title>Powers of Products</title>
@@ -158,18 +165,18 @@
         <m>(ab)^3 = a^3b^3</m>. This is known as the
         <term>power of a product rule of exponents</term>:
       </p>
-
-      <mdn>
-        <mrow xml:id="exponents-power-of-a-product-rule"> \text{Power of a Product Rule of Exponents: }
-          (ab)^m=a^m b^m
-        </mrow>
-      </mdn>
-
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-power-of-a-product-rule"> \text{Power of a Product Rule of Exponents: }
+            (ab)^m=a^m b^m
+          </mrow>
+        </mdn>
+      </p>
       <p>It is important that we only use the power of a product rule with multiplication inside parentheses. This property does NOT work if there is addition or subtraction inside the parentheses.</p>
       <aside>
-      <alert>WARNING:</alert>
-      <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Warning 204 pg 179-->
       <p>
+        <alert>WARNING:</alert>
+        <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Warning 204 pg 179-->
         <md>
           <mrow>(a+b)^n\ne a^n+b^n \amp\amp\amp \text{These are NOT equal if \(n\ne 1\), beware of this error!}</mrow>
         </md>
@@ -203,12 +210,13 @@
         <m>\left(\frac{a}{b} \right)^3=\frac{a^3}{b^3}</m>. This is known as the
         <term>power of a quotient rule of exponents</term>:
       </p>
-
-      <mdn>
-        <mrow xml:id="exponents-power-of-a-quotient-rule"> \text{Power of a Quotient Rule of Exponents: }
-          \left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}
-        </mrow>
-      </mdn>
+      <p>
+        <mdn>
+          <mrow xml:id="exponents-power-of-a-quotient-rule"> \text{Power of a Quotient Rule of Exponents: }
+            \left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}
+          </mrow>
+        </mdn>
+      </p>
 
       <p>We may need to use several rules to simplify an expression. This is shown in the following examples:</p>
       <example>
@@ -216,7 +224,7 @@
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 206 pg 179-->
         <p>Simplify.
         <md>
-          <mrow>(x^3y)^4 \amp\amp\amp \text{Raise each factor to the <m>4^{th}</m> power, multiply exponents}</mrow>
+          <mrow>(x^3y)^4 \amp\amp\amp \text{Raise each factor to the }4^{\mathrm{th}}\text{ power, multiply exponents}</mrow>
           <mrow>x^{12} y^4 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
       </p>
@@ -233,7 +241,7 @@
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 207 pg 180-->
         <p>Simplify.
         <md>
-          <mrow>\left(\dfrac{a^3 b}{c^4 d^5} \right)^2 \amp\amp\amp \text{Raise each factor to the <m>2^{nd}</m> power, multiply exponents}</mrow>
+          <mrow>\left(\dfrac{a^3 b}{c^4 d^5} \right)^2 \amp\amp\amp \text{Raise each factor to the }2^{\mathrm{nd}}\text{ power, multiply exponents}</mrow>
           <mrow>\dfrac{a^6 b^2}{c^8d^{10}} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
       </p>
@@ -250,7 +258,7 @@
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 208 pg 180-->
         <p>Simplify.
         <md>
-          <mrow>(4x^2 y^5)^3 \amp\amp\amp \text{Raise each factor to the <m>3^{rd}</m> power, multiply exponents}</mrow>
+          <mrow>(4x^2 y^5)^3 \amp\amp\amp \text{Raise each factor to the }3^{\mathrm{rd}}\text{ power, multiply exponents}</mrow>
           <mrow>4^3 x^6 y^{15} \amp\amp\amp \text{Evaluate \(4^3=4\cdot 4\cdot 4\)}</mrow>
           <mrow>64x^6 y^{15} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
@@ -261,8 +269,7 @@
         <m>12</m>: this would have been incorrect. Never multiply a base by the exponent.
       </p>
       <p>The exponent properties are summarized in the following table:</p>
-
-<!--      <table>  -->
+      <sidebyside>
         <tabular top="major" halign="center">
             <col halign="left" />
             <col halign="right" />
@@ -291,8 +298,7 @@
               <cell><m>\left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}</m><xref ref="exponents-power-of-a-quotient-rule" /></cell>
             </row>
           </tabular>
-<!--        </table>  -->
-
+        </sidebyside>
       <p>Generally, simplifying an expression requires a combination of properties, and deciding which property to use first may be confusing. However, the order of operations
        <!-- <term>PEMDAS</term> (see <xref ref="section-00-preliminaries" autoname="yes" /> ) -->
        always applies and can be your guide. You should simplify inside any parentheses first, then simplify any exponents (using power rules), and finally simplify any multiplication or division (using product and quotient rules).
@@ -421,9 +427,8 @@
       </p>
       </example>
       <p>Following are the rules of negative exponents:</p>
-
-<!--      <table>  -->
-        <tabular top="major" halign="center">
+        <sidebyside>
+          <tabular top="major" halign="center">
             <col halign="center" />
             <!--  -->
             <row bottom="minor" halign="center">
@@ -442,8 +447,7 @@
               <cell><m>\left( \dfrac{a}{b}\right)^{-m}=\dfrac{b^m}{a^m}</m></cell>
             </row>
           </tabular>
- <!--       </table>  -->
-
+        </sidebyside>
       <p>The rules of exponents apply to negative exponents as well as positive exponents. It is convenient to keep the negative exponents until the end of the problem and then "move them around" to their correct location (numerator or denominator). It is important to be very careful of rules for adding, subtracting, and multiplying with negatives.</p>
       <example>
         <title>Negative Exponents</title>

--- a/src/set1C_Exponents_and_Scientific_Notation.mbx
+++ b/src/set1C_Exponents_and_Scientific_Notation.mbx
@@ -91,8 +91,8 @@
         <p>Write the expression without parenthesis.  Combine like terms.
         <md>
           <mrow>2t(3t+1)-4(5-t^2) \amp\amp\amp \text{Distribute the } 2t \text{ and } -4</mrow>
-          <mrow>2t \cdot 3t+2t \cdot 1 - 4\cdot 5- 4 \cdot -t^2 \amp\amp\amp \text{Simplify }</mrow> 
-           <mrow>6t^2+2t-20+4t^2 \amp\amp\amp \text{Combine like terms }</mrow>                   
+          <mrow>2t \cdot 3t+2t \cdot 1 - 4\cdot 5- 4 \cdot -t^2 \amp\amp\amp \text{Simplify }</mrow>
+           <mrow>6t^2+2t-20+4t^2 \amp\amp\amp \text{Combine like terms }</mrow>
           <mrow>10t^2+2t-20 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
       </p>
@@ -120,7 +120,7 @@
           \frac{a^m}{ a^n} =a^{m-n}
         </mrow>
       </mdn>
-      
+
       <p>The quotient rule of exponents may be used to divide powers by subtracting exponents on like bases. This is shown in the following examples:</p>
       <example>
         <title>Quotient Rule of Exponents</title>
@@ -225,7 +225,7 @@
           \left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}
         </mrow>
       </mdn>
-      
+
       <p>We may need to use several rules to simplify an expression. This is shown in the following examples:</p>
       <example>
         <title>Simplify Exponents</title>
@@ -259,7 +259,7 @@
         <m>5</m> by
         <m>3</m>, rather we multiply
         <m>5</m> three times,
-        <m>5 \cdot 5 \cdot 5 = 125</m>. 
+        <m>5 \cdot 5 \cdot 5 = 125</m>.
       </p>
       <example>
         <title>Simplify Exponents</title>
@@ -272,7 +272,7 @@
         </md>
       </p>
       </example>
-      <p>In the previous example we did not multipy 
+      <p>In the previous example we did not multipy
         <m>4</m> by the exponent <m>3</m> to get
         <m>12</m>: this would have been incorrect. Never multiply a base by the exponent.
       </p>
@@ -308,9 +308,9 @@
             </row>
           </tabular>
 <!--        </table>  -->
-          
+
       <p>Generally, simplifying an expression requires a combination of properties, and deciding which property to use first may be confusing. However, the order of operations
-       <!-- <term>PEMDAS</term> (see <xref ref="section-00-preliminaries" autoname="yes" /> ) --> 
+       <!-- <term>PEMDAS</term> (see <xref ref="section-00-preliminaries" autoname="yes" /> ) -->
        always applies and can be your guide. You should simplify inside any parentheses first, then simplify any exponents (using power rules), and finally simplify any multiplication or division (using product and quotient rules).
       </p>
       <example>
@@ -497,33 +497,32 @@
     </assemblage>
 
       <p>We now have the following nine properties of exponents.</p>
-
-<!--      <table>  -->
+      <sidebyside>
         <tabular top="major" halign="center">
-            <col halign="center" />
-            <col halign="center" />
-            <col halign="center" />
-            <!--  -->
-            <row bottom="minor">
-              <cell colspan="3">Properties of Exponents</cell>
-            </row>
-            <row>
-              <cell><m>a^m a^n=a^{m+n}</m></cell>
-              <cell><m>(ab)^m=a^m b^m</m></cell>
-              <cell><m>a^{-m}=\dfrac{1}{a^m}</m></cell>
-            </row>
-            <row>
-              <cell><m>\frac{a^m}{a^n}=a^{m-n}</m></cell>
-              <cell><m>\left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}</m></cell>
-              <cell><m>\dfrac{1}{a^{-m}}= a^m</m></cell>
-            </row>
-            <row>
-              <cell><m>(a^m)^n=a^{mn}</m></cell>
-              <cell><m>a^0=1</m></cell>
-              <cell><m>\left( \dfrac{a}{b}\right)^{-m}=\dfrac{b^m}{a^m}</m></cell>
-            </row>
-          </tabular>
- <!--       </table>  -->
+          <col halign="center" />
+          <col halign="center" />
+          <col halign="center" />
+          <!--  -->
+          <row bottom="minor">
+            <cell colspan="3">Properties of Exponents</cell>
+          </row>
+          <row>
+            <cell><m>a^m a^n=a^{m+n}</m></cell>
+            <cell><m>(ab)^m=a^m b^m</m></cell>
+            <cell><m>a^{-m}=\dfrac{1}{a^m}</m></cell>
+          </row>
+          <row>
+            <cell><m>\frac{a^m}{a^n}=a^{m-n}</m></cell>
+            <cell><m>\left(\frac{a}{b} \right)^m=\frac{a^m}{b^m}</m></cell>
+            <cell><m>\dfrac{1}{a^{-m}}= a^m</m></cell>
+          </row>
+          <row>
+            <cell><m>(a^m)^n=a^{mn}</m></cell>
+            <cell><m>a^0=1</m></cell>
+            <cell><m>\left( \dfrac{a}{b}\right)^{-m}=\dfrac{b^m}{a^m}</m></cell>
+          </row>
+        </tabular>
+      </sidebyside>
     </subsection>
     <subsection>
       <title>Scientific Notation</title>
@@ -547,12 +546,14 @@
       <example>
         <title>Convert Standard to Scientific: Large number</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 221 pg 188-->
-        <md>
-          <mrow>\text{Convert \(14,200\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
-          <mrow>1.42 \amp\amp\amp \text{Exponent is how many times decimal moved, \(4\)}</mrow>
-          <mrow>\times 10^4 \amp\amp\amp \text{Positive exponent, standard notation is big}</mrow>
-          <mrow>1.42 \times 10^4 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(14,200\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
+            <mrow>1.42 \amp\amp\amp \text{Exponent is how many times decimal moved, \(4\)}</mrow>
+            <mrow>\times 10^4 \amp\amp\amp \text{Positive exponent, standard notation is big}</mrow>
+            <mrow>1.42 \times 10^4 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>When scientific notation is used to represent small numbers, the format requires the number be rewritten as a "bigger" value:
       <m>0.0021</m> must be written as
@@ -566,19 +567,21 @@
       <m>\frac{1}{10}</m> and negative exponents allow us to write the fraction as a power of 10:
       <m>10^{-1} = \frac{1}{10}.</m> To finish the conversion of
       <m>0.0021</m> to scientific notation:
-      <m>0.0021 = 2.1 \times 10^{-3}.</m> 
+      <m>0.0021 = 2.1 \times 10^{-3}.</m>
       </p>
       <example>
         <title>Convert Standard to Scientific: Small number</title>
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 222 pg 188-->
         </p>
-        <md>
-          <mrow>\text{Convert \(0.0042\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
-          <mrow>4.2 \amp\amp\amp \text{Exponent is how many times decimal moved, \(3\)}</mrow>
-          <mrow>\times 10^{-3} \amp\amp\amp \text{Small standard number means a negative exponent}</mrow>
-          <mrow>4.2 \times 10^{-3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(0.0042\) to scientific notation} \amp\amp\amp \text{Put decimal after first nonzero number}</mrow>
+            <mrow>4.2 \amp\amp\amp \text{Exponent is how many times decimal moved, \(3\)}</mrow>
+            <mrow>\times 10^{-3} \amp\amp\amp \text{Small standard number means a negative exponent}</mrow>
+            <mrow>4.2 \times 10^{-3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>To decide which direction to move the decimal (left or right) we simply need to remember that positive exponents mean we have a big number (bigger than ten) in standard notation, and negative exponents mean we have a small number (less than one) in standard notation. The negative exponent simply informs us that we are dealing with a small number.</p>
       <assemblage>
@@ -593,7 +596,7 @@
         </p>
         <p>For exponents with two or more digits, enter
           <c>7.24 x 10^21</c> for
-          <m>7.24 \times 10^{21}.</m> 
+          <m>7.24 \times 10^{21}.</m>
         </p>
       </assemblage>
       <example>
@@ -601,20 +604,24 @@
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 223 pg 189-->
         </p>
-        <md>
-          <mrow>\text{Convert \(3.21\times 10^5\) to standard notation} \amp\amp\amp \text{Positive exponent: Move decimal right \(5\) places}</mrow>
-          <mrow>321,000 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(3.21\times 10^5\) to standard notation} \amp\amp\amp \text{Positive exponent: Move decimal right \(5\) places}</mrow>
+            <mrow>321,000 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Convert Scientific to Standard</title>
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 224 pg 189-->
         </p>
-        <md>
-          <mrow>\text{Convert \(7.4\times 10^{-3}\) to standard notation} \amp\amp\amp \text{Negative exponent: Move decimal left \(3\) places}</mrow>
-          <mrow>0.0074 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\text{Convert \(7.4\times 10^{-3}\) to standard notation} \amp\amp\amp \text{Negative exponent: Move decimal left \(3\) places}</mrow>
+            <mrow>0.0074 \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>When you use a calculator or computer, sometimes scientific notation will be displayed a little differently.  The number will look like <c>2.341 E03</c> or <c>2.341 e03</c>.  In this case, the <c>E03</c> is short for "<m>\times 10^3</m>" and the number is <m>2.341 \times 10^3</m>.</p>
       <example>
@@ -622,11 +629,13 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>\text{Convert } 5.915 E-12  \text{ to scientific notation} \amp\amp\amp \text{Exponent on \(10\) is \(-12\)}</mrow>
-          <mrow>5.915 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
-      </example>      
+        <p>
+          <md>
+            <mrow>\text{Convert } 5.915 E-12  \text{ to scientific notation} \amp\amp\amp \text{Exponent on \(10\) is \(-12\)}</mrow>
+            <mrow>5.915 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
+      </example>
 
     </subsection>
     <subsection>
@@ -639,36 +648,42 @@
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 225 pg 189-->
         </p>
-        <md>
-          <mrow>(2.1\times 10^{-7})(3.7\times 10^{5}) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>(2.1)(3.7)=7.77 \amp\amp\amp \text{Multiply front numbers}</mrow>
-          <mrow>10^{-7} 10^5=10^{-2} \amp\amp\amp \text{Use product rule on \(10\)'s and add exponents}</mrow>
-          <mrow>7.77 \times 10^{-2} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>(2.1\times 10^{-7})(3.7\times 10^{5}) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>(2.1)(3.7)=7.77 \amp\amp\amp \text{Multiply front numbers}</mrow>
+            <mrow>10^{-7} 10^5=10^{-2} \amp\amp\amp \text{Use product rule on \(10\)'s and add exponents}</mrow>
+            <mrow>7.77 \times 10^{-2} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Division with Scientific Notation</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 226 pg 189-->
-        <md>
-          <mrow>\dfrac{4.96\times 10^{4}}{3.1\times 10^{-3}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>\dfrac{4.96}{3.1}=1.6 \amp\amp\amp \text{Divide front numbers}</mrow>
-          <mrow>\dfrac{10^{4}}{10^{-3}}=10^{7} \amp\amp\amp \text{Use quotient rule to subtract exponents,}</mrow>
-          <mrow>\text{ }\amp\amp\amp \text{be careful with negatives!}</mrow>
-          <mrow>\text{ }\amp\amp\amp 4-(-3)=4+3=7</mrow>
-          <mrow>1.6 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\dfrac{4.96\times 10^{4}}{3.1\times 10^{-3}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>\dfrac{4.96}{3.1}=1.6 \amp\amp\amp \text{Divide front numbers}</mrow>
+            <mrow>\dfrac{10^{4}}{10^{-3}}=10^{7} \amp\amp\amp \text{Use quotient rule to subtract exponents,}</mrow>
+            <mrow>\text{ }\amp\amp\amp \text{be careful with negatives!}</mrow>
+            <mrow>\text{ }\amp\amp\amp 4-(-3)=4+3=7</mrow>
+            <mrow>1.6 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Powers with Scientific Notation</title>
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 227 pg 190-->
         </p>
-        <md>
-          <mrow>(1.8\times 10^{-4})^3 \amp\amp\amp \text{Use power rule to deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>(1.8)^3=5.832 \amp\amp\amp \text{Evaluate \((1.8)^3\)}</mrow>
-          <mrow>(10^{-4})^3=10^{-12} \amp\amp\amp \text{Multiply exponents}</mrow>
-          <mrow>5.832 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>(1.8\times 10^{-4})^3 \amp\amp\amp \text{Use power rule to deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>(1.8)^3=5.832 \amp\amp\amp \text{Evaluate \((1.8)^3\)}</mrow>
+            <mrow>(10^{-4})^3=10^{-12} \amp\amp\amp \text{Multiply exponents}</mrow>
+            <mrow>5.832 \times 10^{-12} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>After computation, if the front number is greater than <m>10,</m> we convert the front number into scientific notation and then simplify the expression.
       </p>
@@ -677,28 +692,32 @@
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 228 pg 190-->
         </p>
-        <md>
-          <mrow>(4.7\times 10^{-3})(6.1\times 10^9) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>(4.7)(6.1)=28.67 \amp\amp\amp \text{Multiply the front numbers}</mrow>
-          <mrow>2.867\times 10^1 \amp\amp\amp \text{Convert the front to scientific notation}</mrow>
-          <mrow>10^1 10^{-3} 10^9=10^{7} \amp\amp\amp \text{Use the Product Rule: add exponents include the \(10^1\) from front conversion}
-          </mrow>
-          <mrow>2.867 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>(4.7\times 10^{-3})(6.1\times 10^9) \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>(4.7)(6.1)=28.67 \amp\amp\amp \text{Multiply the front numbers}</mrow>
+            <mrow>2.867\times 10^1 \amp\amp\amp \text{Convert the front to scientific notation}</mrow>
+            <mrow>10^1 10^{-3} 10^9=10^{7} \amp\amp\amp \text{Use the Product Rule: add exponents include the \(10^1\) from front conversion}
+            </mrow>
+            <mrow>2.867 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <example>
         <title>Division with Scientific Notation</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 229 pg 190-->
-        <md>
-          <mrow>\dfrac{2.014\times 10^{-3}}{3.8\times 10^{-7}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
-          <mrow>\dfrac{2.014}{3.8}=0.53 \amp\amp\amp \text{Divide numbers}</mrow>
-          <mrow>0.53=5.3\times 10^{-1} \amp\amp\amp \text{Convert this number into scientific notation}</mrow>
-          <mrow>\dfrac{10^{-1} 10^{-3}}{ 10^{-7}}=10^{3} \amp\amp\amp \text{Use product and quotient rule,}</mrow>
-          <mrow>\text{ }\amp\amp\amp \text{using \(10^{-1}\) from the conversion}</mrow>
-          <mrow>\text{ }\amp\amp\amp \text{Be careful with signs:}</mrow>
-          <mrow>\text{ }\amp\amp\amp (-1)+(-3)-(-7)=(-1)+(-3)+7=7-4=3</mrow>
-          <mrow>5.3 \times 10^{3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\dfrac{2.014\times 10^{-3}}{3.8\times 10^{-7}} \amp\amp\amp \text{Deal with front numbers and \(10\)'s separately}</mrow>
+            <mrow>\dfrac{2.014}{3.8}=0.53 \amp\amp\amp \text{Divide numbers}</mrow>
+            <mrow>0.53=5.3\times 10^{-1} \amp\amp\amp \text{Convert this number into scientific notation}</mrow>
+            <mrow>\dfrac{10^{-1} 10^{-3}}{ 10^{-7}}=10^{3} \amp\amp\amp \text{Use product and quotient rule,}</mrow>
+            <mrow>\text{ }\amp\amp\amp \text{using \(10^{-1}\) from the conversion}</mrow>
+            <mrow>\text{ }\amp\amp\amp \text{Be careful with signs:}</mrow>
+            <mrow>\text{ }\amp\amp\amp (-1)+(-3)-(-7)=(-1)+(-3)+7=7-4=3</mrow>
+            <mrow>5.3 \times 10^{3} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
 
     </subsection>
@@ -710,12 +729,14 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Write both numbers in standard notation}</mrow>
-          <mrow>2,360,000 + 9,700,000 \amp\amp\amp \text{Add numbers}</mrow>
-          <mrow>12,060,000 \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Write both numbers in standard notation}</mrow>
+            <mrow>2,360,000 + 9,700,000 \amp\amp\amp \text{Add numbers}</mrow>
+            <mrow>12,060,000 \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>Because both numbers were times
         <m>10^6</m>, we also could have combined like terms involving
@@ -726,26 +747,30 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Combine like terms involving \(10^6\)}</mrow>
-          <mrow>(2.36+ 9.7)\times 10^{6} \amp\amp\amp \text{Add front numbers}</mrow>
-          <mrow>(12.06)\times 10^{6} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>(1.206 \times 10^1)\times 10^{6} \amp\amp\amp \text{Add exponents: \(10^1\times 10^6 = 10^{1+6}\)}</mrow>
-          <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>2.36\times 10^{6}+ 9.7\times 10^{6} \amp\amp\amp \text{Combine like terms involving \(10^6\)}</mrow>
+            <mrow>(2.36+ 9.7)\times 10^{6} \amp\amp\amp \text{Add front numbers}</mrow>
+            <mrow>(12.06)\times 10^{6} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>(1.206 \times 10^1)\times 10^{6} \amp\amp\amp \text{Add exponents: \(10^1\times 10^6 = 10^{1+6}\)}</mrow>
+            <mrow>1.206 \times 10^{7} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>Subtraction of numbers written using scientific notation is similar.</p>
       <example>
         <title>Subtraction with Scientific Notation</title>
         <!-- Our own-->
         <p>Subtract and write the result using scientific notation.</p>
-        <md>
-          <mrow>4.77\times 10^{-7}- 4.86\times 10^{-7} \amp\amp\amp \text{Combine like terms involving \(10^{-7}\)}</mrow>
-          <mrow>(4.77-4.86)\times 10^{-7} \amp\amp\amp \text{Subtract front numbers}</mrow>
-          <mrow>(-0.09)\times 10^{-7} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>(-9.0 \times 10^{-2})\times 10^{-7} \amp\amp\amp \text{Add exponents: \(10^{-2}\times 10^{-7} = 10^{-2-7}\)}</mrow>
-          <mrow>-9.0 \times 10^{-9} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>4.77\times 10^{-7}- 4.86\times 10^{-7} \amp\amp\amp \text{Combine like terms involving \(10^{-7}\)}</mrow>
+            <mrow>(4.77-4.86)\times 10^{-7} \amp\amp\amp \text{Subtract front numbers}</mrow>
+            <mrow>(-0.09)\times 10^{-7} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>(-9.0 \times 10^{-2})\times 10^{-7} \amp\amp\amp \text{Add exponents: \(10^{-2}\times 10^{-7} = 10^{-2-7}\)}</mrow>
+            <mrow>-9.0 \times 10^{-9} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>If the scientific numbers do not both involve the same power of
         <m>10</m>, we adjust one of the numbers to match the power of
@@ -756,15 +781,17 @@
         <p>
           <!-- Our own-->
         </p>
-        <md>
-          <mrow>8.93\times 10^{13}- 9.26\times 10^{14} \amp\amp\amp \text{Rewrite \(10^{14}\) as \(10^1\times 10^{13}\) to match the other power of \(13\)}</mrow>
-          <mrow>8.93\times 10^{13}- 9.26\times 10^1 \times 10^{13} \amp\amp\amp \text{Multiply \(-9.26\times 10^{1}\)}</mrow>
-          <mrow>8.93\times 10^{13}- 92.6\times 10^{13} \amp\amp\amp \text{Combine like terms involving \(10^{13}\)}</mrow>
-          <mrow>(8.93-92.6)\times 10^{13} \amp\amp\amp \text{Subtract front numbers}</mrow>
-          <mrow>(-83.67)\times 10^{13} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
-          <mrow>(-8.367 \times 10^{1})\times 10^{13} \amp\amp\amp \text{Add exponents: \(10^{1}\times 10^{13} = 10^{1+13}\)}</mrow>
-          <mrow>-8.367 \times 10^{14} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>8.93\times 10^{13}- 9.26\times 10^{14} \amp\amp\amp \text{Rewrite \(10^{14}\) as \(10^1\times 10^{13}\) to match the other power of \(13\)}</mrow>
+            <mrow>8.93\times 10^{13}- 9.26\times 10^1 \times 10^{13} \amp\amp\amp \text{Multiply \(-9.26\times 10^{1}\)}</mrow>
+            <mrow>8.93\times 10^{13}- 92.6\times 10^{13} \amp\amp\amp \text{Combine like terms involving \(10^{13}\)}</mrow>
+            <mrow>(8.93-92.6)\times 10^{13} \amp\amp\amp \text{Subtract front numbers}</mrow>
+            <mrow>(-83.67)\times 10^{13} \amp\amp\amp \text{Write the result in scientific notation}</mrow>
+            <mrow>(-8.367 \times 10^{1})\times 10^{13} \amp\amp\amp \text{Add exponents: \(10^{1}\times 10^{13} = 10^{1+13}\)}</mrow>
+            <mrow>-8.367 \times 10^{14} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
     </subsection>
   </section>

--- a/src/set2A_Equations_and_Absolute_Value.mbx
+++ b/src/set2A_Equations_and_Absolute_Value.mbx
@@ -1,11 +1,13 @@
 <section xml:id="section-2A-equations-and-absolute-value">
   <title>Equations and Absolute Value</title>
   <introduction>
-    <ul>
-      <li>Solve equations (including equations with variables on both sides) by balancing and using inverse operations.</li>
-      <li>Solve linear absolute value equations.</li>
-      <li>Solve linear distance equation problems.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Solve equations (including equations with variables on both sides) by balancing and using inverse operations.</li>
+        <li>Solve linear absolute value equations.</li>
+        <li>Solve linear distance equation problems.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Solution to an Equation</title>
@@ -44,7 +46,7 @@
     </example>
     <p>Now the equation is a true statement! Notice also that if another number, for example,
       <m>3</m>, were plugged in for
-      <m>x</m>, we would not get a true statement as seen in 
+      <m>x</m>, we would not get a true statement as seen in
       <xref ref="not-a-solution" autoname="yes" />.
     </p>
     <example xml:id="not-a-solution">
@@ -88,7 +90,7 @@
       </md>
     </p>
     </example>
-    
+
       <assemblage>
         <title>WeBWorK: Entering Solutions to Equations</title>
         <p>Enter the entire expression
@@ -98,7 +100,7 @@
         <p> When you are solving an equation on paper, your final answer may be in the form <m>3=t</m>.  In WeBWorK, you must enter your answer with the variable on the left side of the equal sign: <c>t = 3</c>
       </p>
       </assemblage>
-    
+
     <!--  The same process is used in each of the following examples.
         </p>
         <example>
@@ -110,9 +112,9 @@
           </md>
         </example>
     -->
-    <p>The terms in an equation may be in any order and the variable may be a letter 
+    <p>The terms in an equation may be in any order and the variable may be a letter
     other than
-      <m>x.</m> The key is to focus on using operations that get 
+      <m>x.</m> The key is to focus on using operations that get
     the variable by itself on one side of the equals sign.
     </p>
     <example>
@@ -132,7 +134,7 @@
     </example>
     <p>In a subtraction problem, we "counteract" negative numbers by adding them to both sides of the equation. For example, consider the following:</p>
     <example>
-      <title>Solve an Equation Involving Subtration</title>
+      <title>Solve an Equation Involving Subtraction</title>
       <p>Solve the equation for
         <m>x.</m>
       <md>
@@ -147,7 +149,7 @@
     </p>
     </example>
       <!--The same process is used in each of the following examples. Notice that each time we are "eliminating" a negative number by adding.-->
-    
+
     <!--
         <example>
           <title>Solve Equations Involving Subtraction</title>
@@ -318,17 +320,19 @@
     <p>To check the correctness of Our Solution we substitute
       <m>x=3</m> back in to the original equation:
     </p>
-    <md>
-      <mrow>4x-20 \amp = -8 \amp\amp \text{Substitute
-        \(x=3\) into the LHS}
-      </mrow>
-      <mrow>4(3)-20 \amp\amp\amp \text{Multiply
-        \(4(3)\)}</mrow>
-      <mrow>12-20 \amp\amp\amp \text{Subtract
-        \(12-20\)}</mrow>
-      <mrow>-8 \amp\amp\amp\text{Compare the LHS to the RHS}</mrow>
-      <mrow>-8\amp =-8\amp\amp\text{LHS=RHS}</mrow>
-    </md>
+    <p>
+      <md>
+        <mrow>4x-20 \amp = -8 \amp\amp \text{Substitute
+          \(x=3\) into the LHS}
+        </mrow>
+        <mrow>4(3)-20 \amp\amp\amp \text{Multiply
+          \(4(3)\)}</mrow>
+        <mrow>12-20 \amp\amp\amp \text{Subtract
+          \(12-20\)}</mrow>
+        <mrow>-8 \amp\amp\amp\text{Compare the LHS to the RHS}</mrow>
+        <mrow>-8\amp =-8\amp\amp\text{LHS=RHS}</mrow>
+      </md>
+    </p>
     <p>Since we get a true statement
       <m>-8=-8</m>, Our Solution
       <m>x=3</m> is correct.<m>\checkmark</m>
@@ -388,7 +392,7 @@
         <mrow>-x\amp = -6\amp\amp \text{Notice negative
       \(1\) is times
       \(x\)}</mrow>
-        <mrow>(-1)(-x)\amp = -6(-1) \amp\amp \text{Multiply both sides by 
+        <mrow>(-1)(-x)\amp = -6(-1) \amp\amp \text{Multiply both sides by
       \(-1\)}</mrow>
       <mrow>\amp\amp\amp\text{(or divide both sides by
       \(-1\)) for the same result}</mrow>
@@ -548,7 +552,6 @@
     <example>
       <title>Check Our Solution <m>x=8</m></title>
       <p>Check that <m>x=8</m> is a solution of the equation <m>4x-6=2x+10.</m></p>
-      <p>
       <sidebyside>
         <p>
           <md>
@@ -569,7 +572,6 @@
             </md>
           </p>
         </sidebyside>
-      </p>
       <!-- <md>
         <mrow>\text{
           LHS:} \amp\amp\amp 4x-6 \amp\amp\amp\text{ } \amp\amp\amp \text{
@@ -669,7 +671,7 @@
           <mrow>x\amp =\frac{21}{2} \amp\amp \text{Our Solution}\checkmark</mrow>
         </md>
       </p>
-    </example>      
+    </example>
     <p>Sometimes we may have to distribute more than once to clear several parentheses. Remember to combine like terms after you distribute!</p>
     <example>
       <title>Distribute and Collect</title>
@@ -751,9 +753,9 @@
           IS a solution by plugging this value back in to the original equation.
         </p>
     </example>
-        
+
       <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace is licensed under a Creative Commons Attribution 3.0 Unported License. (http://creativecommons.org/licenses/by/3.0/) Based on a work at http://wallace.ccfaculty.org/book/book.html. pages 120-->
-    <p>Let's try one involving scientific notation. The fundamental ideas of solving 
+    <p>Let's try one involving scientific notation. The fundamental ideas of solving
         an equation still apply.</p>
     <example>
       <title>Solve an Equation Involving Scientific Notation</title>
@@ -812,7 +814,7 @@
                \draw[color=M101_green] (0,.4) -- (0,.6);
                \draw[color=M101_green] (5,.4) -- (5,.6);
                \node[anchor=south, color=M101_green] at (-2.5,.5) {distance $=5$};
-               \node[anchor=south, color=M101_green] at (2.5,.5) {distance $=5$}; 
+               \node[anchor=south, color=M101_green] at (2.5,.5) {distance $=5$};
              \end{tikzpicture}]]></latex-image-code>
         </image>
  <!--     </figure> -->
@@ -823,12 +825,14 @@
         <p>
           <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 84 pg 52-->
         </p>
-        <md>
-          <mrow>\lvert x\rvert  = 5 \amp\amp\amp \text{Absolute value can be positive or negative}</mrow>
-          <mrow>\text{
-            \(x=5\) or
-            \(x=-5\)} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\lvert x\rvert  = 5 \amp\amp\amp \text{Absolute value can be positive or negative}</mrow>
+            <mrow>\text{
+              \(x=5\) or
+              \(x=-5\)} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
         <p>Notice that we have determined two possibilities, both the positive and negative. Either way, the absolute value of our number will be positive
           <m>7.</m>
         </p>
@@ -840,7 +844,7 @@
         </p>
       </assemblage>
       <p>
-        Absolute value may also be used to define the distance from a point other than zero.  Note that the "distance" between two numbers is the <term>positive difference</term> between the numbers--the absolute value.
+        Absolute value may also be used to define the distance from a point other than zero.  Note that the "distance" between two numbers is the <term>positive difference</term> between the numbers<mdash/>the absolute value.
       </p>
       <example>
       <title>Distance Equation</title>
@@ -851,11 +855,10 @@
         <m>7.</m> Determine
         <m>x</m> and write an absolute value equation that describes this situation.
       </p>
-      <p>
-        The difference between <m>x</m> and <m>4</m> is <m>x-4</m> and the difference between the numbers could be to the right (<m>+7</m>) or to the left (<m>-7</m>) of <m>4</m>.
+      <p>The difference between <m>x</m> and <m>4</m> is <m>x-4</m> and the difference between the numbers could be to the right (<m>+7</m>) or to the left (<m>-7</m>) of <m>4</m>.</p>
         <!--REDO THE TEXT SO THAT EACH CALCULATION LINES UP WITH THE SIDE OF THE GRAPH THAT MATCHES IT.-->
 
- <!--     <figure xml:id="figure-absolute-value-distance-from-4-is-7"> -->
+      <sidebyside>
         <image xml:id="absolute-value-distance-from-4-is-7">
           <latex-image-code><![CDATA[
             \begin{tikzpicture} \draw[<->] (-4.5,0) -- (12.5,0);
@@ -869,20 +872,20 @@
                \draw[color=M101_green] (4,.4) -- (4,.6);
                \draw[color=M101_green] (11,.4) -- (11,.6);
                \node[anchor=south, color=M101_green] at (0,.5) {$x-2=-3$};
-               \node[anchor=south, color=M101_green] at (7,.5) {$x-2=3$}; 
+               \node[anchor=south, color=M101_green] at (7,.5) {$x-2=3$};
              \end{tikzpicture}]]></latex-image-code>
         </image>
- <!--     </figure>  -->
-
-      <md>
-        <mrow> \text{ Solve: } \amp x-4=7 \amp\amp \text{ \(x = 7+4 = 11\) is \(7\) units to the right of \(4\)}</mrow>
-        <mrow>  \text{ Solve: } \amp x-4=-7 \amp\amp \text{\(x = -7+4 = -3\) is \(7\) units to the left of \(4\)}</mrow>
-        <mrow> \amp x=11 \text{ or } x=-3\amp\amp \text{Our Solution}\checkmark</mrow>
-      </md>
-      To denote "the distance between the number <m>x</m> and <m>4</m> is <m>7</m>", we write the difference in absolute value.
-      <md>
-        <mrow>\lvert x-4\rvert =7\amp\amp \text{Absolute value equation that describes this situation}\checkmark</mrow>
-      </md>
+      </sidebyside>
+      <p>
+        <md>
+          <mrow> \text{ Solve: } \amp x-4=7 \amp\amp \text{ \(x = 7+4 = 11\) is \(7\) units to the right of \(4\)}</mrow>
+          <mrow>  \text{ Solve: } \amp x-4=-7 \amp\amp \text{\(x = -7+4 = -3\) is \(7\) units to the left of \(4\)}</mrow>
+          <mrow> \amp x=11 \text{ or } x=-3\amp\amp \text{Our Solution}\checkmark</mrow>
+        </md>
+        To denote "the distance between the number <m>x</m> and <m>4</m> is <m>7</m>", we write the difference in absolute value.
+        <md>
+          <mrow>\lvert x-4\rvert =7\amp\amp \text{Absolute value equation that describes this situation}\checkmark</mrow>
+        </md>
     </p>
     </example>
     <!--Older example
@@ -896,7 +899,7 @@
         <m>x.</m>
       </p>
       <p>
-     <!**  Start by translating the words into an equation.  We will need to translate <term>distance</term> into absolute value. We are given 
+     <!**  Start by translating the words into an equation.  We will need to translate <term>distance</term> into absolute value. We are given
           <ul>
             <li><m>x=</m> the <term>unknown</term> number(s)</li>
             <li>the distance is <m>7</m></li>
@@ -937,11 +940,11 @@
         </p>
         <p>
         <md>
-          <mrow>\underline{x=3:} \amp\amp\amp 
+          <mrow>\underline{x=3:} \amp\amp\amp
             \underline{x=-3:}</mrow>
-          <mrow>5+\lvert 3\rvert  \amp\amp\amp 
+          <mrow>5+\lvert 3\rvert  \amp\amp\amp
             5+\lvert -3\rvert</mrow>
-          <mrow>5+3 = 8\checkmark \amp\amp\amp 
+          <mrow>5+3 = 8\checkmark \amp\amp\amp
             5+3 = 8 \checkmark</mrow>
         </md>
       </p>
@@ -995,7 +998,7 @@
       </example> -->
 <!--      <p>Again we see the same process: consider the distance to the left and right of the value. Often the absolute value will have more than just a variable in it. In this case we consider the positive and negative possibilities and solve the resulting equations. This is shown in the next example.</p>
 -->
-      <p>The next few examples demonstrate the steps to solve a general absolute value equation. Remember that the expression <term>inside</term> the absolute value symbols may be positive or negative--the absolute value will make the value non-negative in the end--so, both possibilities must be solved for to determine all solutions to an absolute value equation.
+      <p>The next few examples demonstrate the steps to solve a general absolute value equation. Remember that the expression <term>inside</term> the absolute value symbols may be positive or negative<mdash/>the absolute value will make the value non-negative in the end<mdash/>so, both possibilities must be solved for to determine all solutions to an absolute value equation.
       </p>
       <example>
         <title>Absolute Value of an Expression</title>
@@ -1071,16 +1074,18 @@
         <p>
           <!-- CofI own-->
         </p>
-        <md>
-          <mrow>\lvert 2x-5\rvert = -4 \amp\amp\amp \text{Notice the problem asks where the expression is negative}</mrow>
-          <mrow> \amp\amp\amp \text{STOP! Result of absolute value can't be negative! }
-          </mrow>
-          <mrow>\text{No solution} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\lvert 2x-5\rvert = -4 \amp\amp\amp \text{Notice the problem asks where the expression is negative}</mrow>
+            <mrow> \amp\amp\amp \text{STOP! Result of absolute value can't be negative! }
+            </mrow>
+            <mrow>\text{No solution} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
+          </md>
+        </p>
       </example>
       <p>Notice in the above example, the absolute value expression equals a negative number! This is impossible with absolute value. When this occurs we
         <alert>STOP</alert> and conclude there is no solution.
-      </p> 
+      </p>
       <assemblage>
         <title>WeBWorK: Enter "No solution"</title>
         <p>If the equation has no solution, type
@@ -1093,18 +1098,20 @@
         <p>
           <!--Owr own-->
         </p>
-        <md>
-          <mrow>\lvert x-3\rvert = 0 \amp\amp\amp \text{What numbers are zero distance from \(3\)?}</mrow>
-          <mrow>x = 3 \amp\amp\amp \text{Only \(3\) is zero distance from itself }\checkmark
-          </mrow>
-          <mrow> \amp\amp\amp </mrow>
-          <mrow> \amp\amp\amp \text{Or we could solve this another way:}
-          </mrow>                              
-          <mrow>x-3 = 0 \amp\amp\amp \text{Since \(-0=0\) we only need one equation to solve}
-          </mrow>
-          <mrow>x=3 \amp\amp\amp \text{Add \(3\) to both sides}\checkmark</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>\lvert x-3\rvert = 0 \amp\amp\amp \text{What numbers are zero distance from \(3\)?}</mrow>
+            <mrow>x = 3 \amp\amp\amp \text{Only \(3\) is zero distance from itself }\checkmark
+            </mrow>
+            <mrow> \amp\amp\amp </mrow>
+            <mrow> \amp\amp\amp \text{Or we could solve this another way:}
+            </mrow>
+            <mrow>x-3 = 0 \amp\amp\amp \text{Since \(-0=0\) we only need one equation to solve}
+            </mrow>
+            <mrow>x=3 \amp\amp\amp \text{Add \(3\) to both sides}\checkmark</mrow>
+          </md>
+        </p>
       </example>
     </subsection>
   </section>
-              
+

--- a/src/set2B_Intervals_and_Inequalities.mbx
+++ b/src/set2B_Intervals_and_Inequalities.mbx
@@ -1,17 +1,19 @@
 <section xml:id="section-2B-intervals-and-inequalities">
   <title>Intervals and Inequalities</title>
   <introduction>
-    <ul>
-      <li>Use inequality and interval notation.</li>
-      <li>Solve linear inequalities.</li>
-      <li>Solve, graph and give interval notation for the solution to inequalities with absolute values.</li>
-      <li>Solve linear distance inequality problems.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Use inequality and interval notation.</li>
+        <li>Solve linear inequalities.</li>
+        <li>Solve, graph and give interval notation for the solution to inequalities with absolute values.</li>
+        <li>Solve linear distance inequality problems.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Intervals and Inequalities</title>
     <p>When we solve an equation we find a single value for our variable. With inequalities we will give a range of values for our variable. To do this we will not use an equals sign, but one of the following symbols:
-    
+
     <md>
       <mrow>\gt \amp\amp\amp \text{Greater than}</mrow>
       <mrow>\geq \amp\amp\amp \text{Greater than or equal to}</mrow>
@@ -24,14 +26,14 @@
       <p>Type the two symbols together:</p>
       <p>
         <c>&gt;=
-        </c>for <m>\geq</m> (greater than or equal to) 
+        </c>for <m>\geq</m> (greater than or equal to)
       </p>
       <p>
         <c>&lt;=
         </c> for <m>\leq</m> (greater than or equal to)
       </p>
     </assemblage>
-    <p>The expression 
+    <p>The expression
       <m>x \lt 4</m> this means our variable <m>x</m> can be any number smaller than
       <m>4</m> such as
       <m>-2, 0, 3, 3.9</m> or even
@@ -40,7 +42,7 @@
       <m>x \lt 4</m> is the set of all numbers less than
       <m>4</m>. <alert>4 is NOT less than 4</alert>.  We write <m>4\nless 4</m>.  However <m>4</m> IS less than or equal to <m>4</m>.  We write <m>4\leq 4</m>.
     </p>
-    <p>The expression 
+    <p>The expression
       <m>y \geq -2,</m> means that the variable <m>y</m> can be any number greater than or equal to
       <m>-2,</m> such as
       <m>5, 0,-1,-1.9999,</m> or even
@@ -62,44 +64,41 @@
       <title>Relating an Inequality, Graph and Interval</title>
         <!-- Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 151 pg 119 and WeBWorK Problems/MAT105_Templates/setAlgebra_04_01_LinearInequalities/41IntAlg_03_LinearIneq.pg-->
       <p>Graph the inequality <m>x\geq 4</m> and give the interval notation.
-        <sidebyside widths="55% 40%" valign="middle">
- <!--         <figure xml:id="figure-interval-x-geq-4"> -->
-            <image xml:id="interval-x-geq-4">
-              <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[fill=red] (4,.5) circle (.1cm); \draw[->, red] (4,.5) -- (5.5,.5); \end{tikzpicture} ]]></latex-image-code>
-              </image>
- <!--           </figure>  -->
-            <paragraphs>
-              <p>Start at <m>4</m> and shade to the right. Use a closed circle for greater than or equal to.
-              </p>
-              <p>Our Graph<m>\checkmark</m></p>
-              <p>Interval notation:
-                <m>[4,\infty ) \checkmark</m>
-              </p>
-            </paragraphs>
-          </sidebyside>
-        </p>
-      </example>
-      
+      </p>
+      <sidebyside widths="55% 40%" valign="middle">
+        <image xml:id="interval-x-geq-4">
+          <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+            <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[fill=red] (4,.5) circle (.1cm); \draw[->, red] (4,.5) -- (5.5,.5); \end{tikzpicture} ]]></latex-image-code>
+        </image>
+        <paragraphs>
+          <p>Start at <m>4</m> and shade to the right. Use a closed circle for greater than or equal to.
+          </p>
+          <p>Our Graph<m>\checkmark</m></p>
+          <p>Interval notation:
+            <m>[4,\infty ) \checkmark</m>
+          </p>
+        </paragraphs>
+      </sidebyside>
+    </example>
+
       <assemblage>
         <title>WeBWorK: Entering Intervals</title>
         <p>Type
           <c>[4,inf)</c> for the interval <m>[4,\infty )</m>.
         </p>
       </assemblage>
-            
+
       <example>
         <title>Relating an Inequality, Graph and Interval</title>
-        <p>Graph the inequality <m>x\lt -4</m> and give the interval notation.
+        <p>Graph the inequality <m>x\lt -4</m> and give the interval notation.</p>
           <!-- Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 151 pg 119 and WeBWorK Problems/MAT105_Templates/setAlgebra_04_01_LinearInequalities/41IntAlg_02_LinearIneq.pg -->
         <sidebyside widths="55% 40%" valign="middle">
- <!--         <figure xml:id="figure-interval-x-lt-neg4">  -->
-            <image xml:id="interval-x-lt-neg4">
-              <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=red] (-4,.5) circle (.1cm); \draw[
-                  <-, red] (-5.5,.5) -- (-4.1,.5); \end{tikzpicture} ]]></latex-image-code>
-                </image>
-  <!--            </figure>  -->
+          <image xml:id="interval-x-lt-neg4">
+            <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+              <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=red] (-4,.5) circle (.1cm); \draw[
+                <-, red] (-5.5,.5) -- (-4.1,.5); \end{tikzpicture} ]]>
+            </latex-image-code>
+          </image>
           <paragraphs>
             <p>Start at <m>-4</m> and shade to the left. Use an open circle for less than.
             </p>
@@ -109,35 +108,32 @@
             </p>
           </paragraphs>
         </sidebyside>
-      </p>
-    </example>
+      </example>
     <assemblage>
       <title>WeBWorK: Entering an Infinity Symbol</title>
-      <p>Type 
+      <p>Type
         <c>(-inf,-4)</c> for the interval <m>(-\infty, -4)</m>.
       </p>
     </assemblage>
     <example>
       <title>Relating an Inequality, Graph and Interval</title>
-      <p>Graph the inequality <m>-3\lt x \lt 1</m> and give the interval notation.
+      <p>Graph the inequality <m>-3\lt x \lt 1</m> and give the interval notation.</p>
         <!-- Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 151 pg 119 and WeBWorK MAT105_Templates/setAlgebra_04_01_LinearInequalities/41IntAlg_04_LinearIneq.pg -->
       <sidebyside widths="55% 40%" valign="middle">
- <!--         <figure xml:id="figure-interval-neg3-lt-x-lt-1">  -->
-              <image xml:id="interval-neg3-lt-x-lt-1">
-                <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=blue] (-3,.5) circle (.1cm); \draw[color=blue] (1,.5) circle (.1cm); \draw[blue] (-2.9,.5) -- (.9,.5); \end{tikzpicture} ]]></latex-image-code>
-                </image>
- <!--             </figure>  -->
-          <paragraphs>
-            <p>Start at <m>-3</m> and shade to the right to <m>1</m>. Use open circles on both ends for less than.
-            </p>
-            <p>Our Graph<m>\checkmark</m></p>
-            <p>Interval notation:
-              <m>(-3, -1) \checkmark</m>
-            </p>
-          </paragraphs>
-        </sidebyside>
-      </p>
+        <image xml:id="interval-neg3-lt-x-lt-1">
+          <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=blue] (-3,.5) circle (.1cm); \draw[color=blue] (1,.5) circle (.1cm); \draw[blue] (-2.9,.5) -- (.9,.5); \end{tikzpicture} ]]>
+          </latex-image-code>
+        </image>
+        <paragraphs>
+          <p>Start at <m>-3</m> and shade to the right to <m>1</m>. Use open circles on both ends for less than.
+          </p>
+          <p>Our Graph<m>\checkmark</m></p>
+          <p>Interval notation:
+            <m>(-3, -1) \checkmark</m>
+          </p>
+        </paragraphs>
+      </sidebyside>
     </example>
             <!-- <p>Intervals represent sets of numbers.  This means we can perform set operations on intervals.  For example:</p> <example> <title>Union of Two Overlapping Intervals</title> <p> <!** Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_01_LinearInequalities/41IntAlg_04_LinearIneq.pg **> </p> <figure xml:id="figure-intervals-overlapping"> <image xml:id="intervals-overlapping"> <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) ## (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) ## (\x, -0.1) node [below] {\x}; \fill[color=green] (2,1) circle (.1cm); \draw[green, <-] (-5.5,1) ## (2,1); \draw[color=blue] (-2,.5) circle (.1cm); \draw[blue, ->] (-1.9,.5) ## (5.5,.5); \end{tikzpicture} ]]></latex-image-code> </image> </figure> <p>The <b>union</b> of the points in the graph would be all values in either the first interval <b>OR</b> in the second (or in both) For example, <m>-3</m> is in the top interval <m>(-\infty, 2]</m>, so <m>-3</m> is in the union and <m>2.7</m> is in the bottom interval <m>(-2, \infty)</m>, so <m>2.7</m> is in the union and <m>-\frac{1}{3}</m> is in both intervals, so <m>-\frac{1}{3}</m> is in the union Notice every real number is either in the top or bottom interval (or in both) </p> <md> <mrow>(-\infty, \infty)\) } \amp\amp\amp \text{An interval describing the union <div class="WWbox">Type <b>(-inf,inf)</b> for the interval \((-\infty, \infty)\)  in <tt>WeBWorK</tt> </div>} </mrow> <mrow>\text{\(-\infty \lt x \lt \infty\) } \amp\amp\amp \text{An inequality describing the union <div class="WWbox">Type <b>-inf <lt /> x <lt /> inf </b> for the inequality \(-\infty \lt x \lt \infty\)  in <tt>WeBWorK</tt> </div>} </mrow> </md> </example> <example> <title>Intersection of Two Overlapping Intervals</title> <p> <!** Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_01_LinearInequalities/41IntAlg_04_LinearIneq.pg **> </p> <figure xml:id="figure-intervals-overlapping-copy"> <image source="../output/images/intervals-overlapping.svg" /> </figure> <p>The <b>intersection</b> of the points in the graph would be all values in both the first interval <b>AND</b> the second This is points common to both (or in the overlap) For example, <m>-3</m> is NOT in the bottom interval <m>(-2, \infty)</m>, so <m>-3</m> is NOT in the intersection and <m>2.7</m> is NOT in the top interval <m>(-\infty, 2]</m>, so <m>2.7</m> is NOT in the intersection but since <m>-\frac{1}{3}</m> is in both intervals, <m>-\frac{1}{3}</m> IS in the intersection </p> <md> <mrow>\text{\((-2, 2]\) } \amp\amp\amp \text{An interval describing the intersection}</mrow> <mrow>\text{\(-2 \lt x \leq 2\) } \amp\amp\amp \text{An inequality describing the intersection}</mrow> </md> </example> <example> <title>Union of Two Overlapping Intervals</title> <p>Describe the <b>union</b> of the points in the graph. <!** Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_02_CompoundIneq/42IntAlg_05_CompoundIneq.pg **> </p> <figure xml:id="figure-intervals-overlapping2"> <image xml:id="intervals-overlapping2"> <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) ## (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) ## (\x, -0.1) node [below] {\x}; \fill[color=red] (-3,1) circle (.1cm); \draw[red, <-] (-5.5,1) ## (-3,1); \draw[color=green] (4,.5) circle (.1cm); \draw[green, <-] (-5.5,.5) ## (3.9,.5); \end{tikzpicture} ]]></latex-image-code> </image> </figure> <p>Recall the <b>union</b> of the points in the graph would be all values in either the first interval <b>OR</b> in the second (or in both) For example, <m>-3</m> is in both the top and bottom intervals, so <m>-3</m> is in the union and <m>2.7</m> is in the bottom interval, so <m>2.7</m> is in the union but <m>5</m> is in neither interval, so <m>5</m> is NOT in the union Notice every number in the bottom interval is in the union (as is every number in the top interval) </p> <md> <mrow>\text{\((-\infty, 4)\) } \amp\amp\amp \text{An interval describing the union}</mrow> <mrow>\text{\(x \lt 4\) } \amp\amp\amp \text{An inequality describing the union}</mrow> </md> </example> <example> <title>Intersection of Two Overlapping Intervals</title> <p>Describe the <b>intersection</b> of the points in the graph. <!** Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_02_CompoundIneq/42IntAlg_05_CompoundIneq.pg **> </p> <figure xml:id="figure-intervals-overlapping2-copy"> <image source="../output/images/intervals-overlapping2.svg" /> </figure> <p>Recall the <b>intersection</b> of the points in the graph would be all values in both the first interval <b>AND</b> the second This is points common to both (or in the overlap) For example, <m>-3</m> is in both the top and bottom intervals, so <m>-3</m> is in the intersection But <m>2.7</m> is in the bottom interval but not the top, so <m>2.7</m> is NOT in the intersection and <m>5</m> is in neither interval, so <m>5</m> is NOT in the intersection Notice the overlap of the two intervals is all numbers in the first interval </p> <md> <mrow>\text{\((-\infty, -3]\) } \amp\amp\amp \text{An interval describing the intersection}</mrow> <mrow>\text{\(x \leq -3\) } \amp\amp\amp \text{An inequality describing the intersection <div class="WWbox">Type <b>x <lt />= -3 </b> for the inequality \(x \leq -3\)  in <tt>WeBWorK</tt> </div>} </mrow> </md> </example> <example> <title>Union of Two Non-Overlapping Intervals</title> <p>Describe the <b>union</b> of the points in the graph. <!** Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_02_CompoundIneq/42IntAlg_07_CompoundIneq.pg **> </p> <figure xml:id="figure-interval-non-overlapping"> <image xml:id="interval-non-overlapping"> <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) ## (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) ## (\x, -0.1) node [below] {\x}; \fill[color=green] (1,1) circle (.1cm); \draw[green, ->] (1,1) ## (5.5,1); \fill[color=red] (-2,.5) circle (.1cm); \draw[red, <-] (-5.5,.5) ## (-2,.5); \end{tikzpicture} ]]></latex-image-code> </image> </figure> <p>Recall the <b>union</b> of the points in the graph would be all values in either the first interval <b>OR</b> in the second (or in both) </p> <md> <mrow>\text{\((-\infty, -2]\cup [1,\infty)\) } \amp\amp\amp \text{A union of intervals describing the union <div class="WWbox">Type capital <b>U</b> for \(\cup\) the union symbol in <tt>WeBWorK</tt> <b>(-inf,-2]U[1,inf)</b> for \((-\infty, -2]\cup [1,\infty)\) </div>} </mrow> <mrow>\text{\(x\leq -2\)  or \(x\geq 1\) } \amp\amp\amp \text{A compound inequality describing the union}</mrow> </md> </example> <example> <title>Intersection of Two Non-Overlapping Intervals</title> <p> <!** Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_02_CompoundIneq/42IntAlg_05_CompoundIneq.pg **> Describe the <b>intersection</b> of the points in the graph. </p> <figure xml:id="figure-interval-non-overlapping-copy"> <image source="../output/images/interval-non-overlapping.svg" /> </figure> <p>The <b>intersection</b> of the points in the graph would be all values common to both (overlap). </p> <md> <mrow>\text{None} \amp\amp\amp \text{There are no values common to both intervals <div class="WWbox">Type <b>None</b> for empty sets in <tt>WeBWorK</tt> </div>} </mrow> </md> </example> <example> <title>Solving Compound Inequalities</title> <p> <!** Modeled after and WeBWorK MAT101_Templates/set1C-Sets_Intervals_Inequalities/22_inequalities.pg **> Solve the compound inequality.</p> <p> <m>x \leq -3</m> and <m>x \lt 4</m></p> <p> First sketch the intervals on a graph. Write the compound inequality in interval notation: <b>AND</b> is intersection. </p> <figure xml:id="figure-intervals-overlapping2-copy2"> <image source="../output/images/intervals-overlapping2.svg" /> </figure> <md> <mrow>\text{\((-\infty,  -3] \cap ( -\infty, 4)\) } \amp\amp\amp \text{The values common to both intervals are shaded red}</mrow> <mrow>\text{\((-\infty,  -3]\) } \amp\amp\amp \text{Our Solution <div class="WWbox">You may enter either the interval <b>(-inf,-3]</b> or the inequality notation <b>x \lt = -3</b> in <tt>WeBWorK</tt> </div>} </mrow> </md> </example> <example> <title>Solving Compound Inequalities</title> <p> <!** Modeled after and WeBWorK MAT101_Templates/set1C-Sets_Intervals_Inequalities/22_inequalities.pg **> Solve the compound inequality. </p> <p> <m>x \leq 2</m> and <m>x \gt -2</m></p> <p>First sketch the intervals on a graph. Write the compound inequality in interval notation: <b>AND</b> is intersection. </p> <figure xml:id="figure-intervals-overlapping-copy2"> <image source="../output/images/intervals-overlapping.svg" /> </figure> <md> <mrow>\text{\((-\infty,  2] \cap ( -2, \infty)\) } \amp\amp\amp \text{The values common to both intervals are in the overlap}</mrow> <mrow>\text{\((-2, 2]\) } \amp\amp\amp \text{Our Solution}</mrow> </md> </example> -->
           </subsection>
@@ -185,63 +181,60 @@
               <title>Solve an Inequality</title>
                 <!-- Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 155 pg 120-->
               <p>Solve and give the interval notation.
-              <md>
-                <mrow>5-2x\amp\geq 11 \amp\amp \text{Subtract \(5\) from both sides}</mrow>
-                <mrow>\underline{-5\phantom{1234}}\amp\underline{\phantom{1}-5} \amp\amp \,</mrow>
-                <mrow>-2x\amp\geq 6 \amp\amp \text{Divide both sides by \(-2\)}</mrow>
-                <mrow>\overline{-2}\amp\phantom{12}\overline{-2} \amp\amp \text{Divide by a negative: flip inequality sign!}</mrow>
-                <mrow>x\amp\color{red}{\leq}\color{black}{}-3 \amp\amp \text{Graph, starting at \(-3\), going left with a solid circle for less than or equal to}</mrow>
-              </md>
-              <sidebyside widths="55% 40%" valign="middle">  
- <!--               <figure xml:id="figure-inequality-solution-x-leq-neg3">  -->
-                  <image xml:id="inequality-solution-x-leq-neg3">
-                    <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                      <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=red] (-3,.5) circle (.1cm); \draw[red,
-                        <-] (-5.5,.5) -- (-3,.5); \end{tikzpicture} ]]></latex-image-code>
-                      </image>
- <!--                   </figure>  -->
-                  <paragraphs>
-                    <p>Our Graph<m>\checkmark</m></p>
-                    <p>Interval notation:
-                      <m>(-\infty, -3] \checkmark</m>
-                    </p>
-                  </paragraphs>
-                </sidebyside>
+                <md>
+                  <mrow>5-2x\amp\geq 11 \amp\amp \text{Subtract \(5\) from both sides}</mrow>
+                  <mrow>\underline{-5\phantom{1234}}\amp\underline{\phantom{1}-5} \amp\amp \,</mrow>
+                  <mrow>-2x\amp\geq 6 \amp\amp \text{Divide both sides by \(-2\)}</mrow>
+                  <mrow>\overline{-2}\amp\phantom{12}\overline{-2} \amp\amp \text{Divide by a negative: flip inequality sign!}</mrow>
+                  <mrow>x\amp\color{red}{\leq}\color{black}{}-3 \amp\amp \text{Graph, starting at \(-3\), going left with a solid circle for less than or equal to}</mrow>
+                </md>
               </p>
+              <sidebyside widths="55% 40%" valign="middle">
+                <image xml:id="inequality-solution-x-leq-neg3">
+                  <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+                    <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=red] (-3,.5) circle (.1cm); \draw[red,
+                      <-] (-5.5,.5) -- (-3,.5); \end{tikzpicture} ]]>
+                  </latex-image-code>
+                </image>
+                <paragraphs>
+                  <p>Our Graph<m>\checkmark</m></p>
+                  <p>Interval notation:
+                    <m>(-\infty, -3] \checkmark</m>
+                  </p>
+                </paragraphs>
+              </sidebyside>
             </example>
             <p>The inequality we solve can get as complex as the linear equations we solved. We will use all the same patterns to solve these inequalities as we did for solving equations. Just remember that any time we multiply or divide by a negative number the inequality symbol switches directions (multiplying or dividing by a positive does not change the symbol!)</p>
             <example>
               <title>Solve an Inequality</title>
                 <!-- Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 156 pg 121-->
-              <p>Solve and give the interval notation.  
+              <p>Solve and give the interval notation.
                 <md>
                   <mrow>3(2x-4)+4x\amp\lt 4(3x-7)+8 \amp\amp \text{Distribute}</mrow>
                   <mrow>6x-12+4x\amp\lt 12x-28+8 \amp\amp \text{Combine like terms}</mrow>
                   <mrow>10x-12\amp\lt 12x-20 \amp\amp \text{"Move" variable to one side}</mrow>
                   <mrow>\underline{-10x\phantom{1234}}\amp\underline{\phantom{1}-10x} \amp\amp \text{Subtract \(10x\) from both sides}</mrow>
-                  <mrow>-12\amp\lt 2x-20 \amp\amp \text{Isolate variable on
-                    <b>RHS</b>}
+                  <mrow>-12\amp\lt 2x-20 \amp\amp \text{Isolate variable on \textbf{RHS}}
                   </mrow>
                   <mrow>\underline{+20}\amp\underline{\phantom{12345}+20} \amp\amp \text{Add \(20\) to both sides}</mrow>
                   <mrow>8\amp\lt 2x \amp\amp \text{Divide both sides by \(2\)}</mrow>
                   <mrow>\overline{2}\amp\phantom{123}\overline{2}\amp\amp \text{Divide by a positive: DON'T flip inequality sign!}</mrow>
                   <mrow>4\amp\lt x \amp\amp \text{Be careful with graph, \(x\) is larger!}</mrow>
                 </md>
-                <sidebyside widths="55% 40%" valign="middle">
- <!--                 <figure xml:id="figure-inequality-solution-x-gt-4">  -->
-                    <image xml:id="inequality-solution-x-gt-4">
-                      <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                        <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=blue] (4,.5) circle (.1cm); \draw[blue, ->] (4.1,.5) -- (5.5,.5); \end{tikzpicture} ]]></latex-image-code>
-                      </image>
- <!--                   </figure>  -->
-                    <paragraphs>
-                      <p>Our Graph<m>\checkmark</m></p>
-                      <p>Interval notation:
-                        <m>(4, \infty)\checkmark</m>
-                      </p>
-                  </paragraphs>
-                </sidebyside>
               </p>
+              <sidebyside widths="55% 40%" valign="middle">
+                <image xml:id="inequality-solution-x-gt-4">
+                  <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+                      <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=blue] (4,.5) circle (.1cm); \draw[blue, ->] (4.1,.5) -- (5.5,.5); \end{tikzpicture} ]]>
+                  </latex-image-code>
+                </image>
+                <paragraphs>
+                  <p>Our Graph<m>\checkmark</m></p>
+                  <p>Interval notation:
+                    <m>(4, \infty)\checkmark</m>
+                  </p>
+                </paragraphs>
+              </sidebyside>
             </example>
             <p>It is important to be careful when the inequality is written backwards as in the previous example (
               <m>4 \lt x</m> rather than
@@ -257,84 +250,88 @@
                   <example>
                     <title>Three-part Compound Inequality</title>
                       <!-- Modeled after our WeBWorK-->
-                    <p>Solve the compound inequality, graph the solution, and express it in both inequality and interval notation.
-                      <sidebyside widths="40% 55%" valign="middle">
-                        <paragraphs>
-                          <p><m>-4\leq 2x-4 \lt 2</m></p>
-                          <p>The inequality requires the expression <m>\color{blue}{2x-4}</m> to lie in the interval <m>[-4,2)</m></p>
-                        </paragraphs>
- <!--                       <figure xml:id="figure-inequality-solution-neg4-leq-2x-4-lt-2">  -->
-                          <image xml:id="inequality-solution-neg4-leq-2x-4-lt-2">
-                            <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                              <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=blue] (-4,.5) circle (.1cm); \draw[color=blue] (2,.5) circle (.1cm); \draw[blue] (-4,.5) -- (1.9,.5); \node[anchor=south, color=blue] at (-1,.5) {$2x-4$}; \end{tikzpicture} ]]></latex-image-code>
-                            </image>
- <!--                         </figure>   -->
-                        </sidebyside>
+                    <p>Solve the compound inequality, graph the solution, and express it in both inequality and interval notation.</p>
+                    <sidebyside widths="40% 55%" valign="middle">
+                      <paragraphs>
+                        <p><m>-4\leq 2x-4 \lt 2</m></p>
+                        <p>The inequality requires the expression <m>\color{blue}{2x-4}</m> to lie in the interval <m>[-4,2)</m></p>
+                      </paragraphs>
+<!--                       <figure xml:id="figure-inequality-solution-neg4-leq-2x-4-lt-2">  -->
+                      <image xml:id="inequality-solution-neg4-leq-2x-4-lt-2">
+                        <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+                          <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=blue] (-4,.5) circle (.1cm); \draw[color=blue] (2,.5) circle (.1cm); \draw[blue] (-4,.5) -- (1.9,.5); \node[anchor=south, color=blue] at (-1,.5) {$2x-4$}; \end{tikzpicture} ]]>
+                        </latex-image-code>
+                      </image>
+                    </sidebyside>
+                    <p>
                       <md>
                         <mrow>-4\leq 2x-4 \lt 2 \amp\amp\amp \text{Add \(4\) to all three parts of the compound inequality}</mrow>
                         <mrow>\underline{+4\phantom{1234}+4\phantom{1}+4} \amp\amp\amp \,</mrow>
                         <mrow>0\leq 2x \lt 6 \amp\amp\amp \text{Divide all three parts by \(2\)}</mrow>
                         <mrow>\overline{ 2 }\phantom{123}\overline{ 2 }\phantom{1234}\overline{ 2 } \amp\amp\amp \,</mrow>
                       </md>
-                      <sidebyside widths="20% 20% 55%" valign="middle">
-                        <p></p>
-                        <p>
-                          <m>0\leq \color{red}{x} \lt 3</m>
-                        </p>
-<!--                        <figure xml:id="figure-inequality-solution-zero-leq-x-lt-3">  -->
-                          <image xml:id="inequality-solution-zero-leq-x-lt-3">
-                            <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                              <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=red] (0,.5) circle (.1cm); \draw[color=red] (3,.5) circle (.1cm); \draw[red] (0,.5) -- (2.9,.5); \node[anchor=south, color=red] at (1.5,.5) {$x$}; \end{tikzpicture} ]]></latex-image-code>
-                            </image>
- <!--                         </figure>  -->
-                        </sidebyside>
-                        <md>
-                          <mrow>0\leq x \lt 3 \amp\amp\amp \text{Our Solution: Inequality Notation}\checkmark</mrow>
-                          <mrow>[0,3) \amp\amp\amp \text{Our Solution: Interval Notation}\checkmark</mrow>
-                        </md>
+                    </p>
+                    <sidebyside widths="20% 20% 55%" valign="middle">
+                      <p></p>
+                      <p>
+                        <m>0\leq \color{red}{x} \lt 3</m>
                       </p>
-                      </example>
-                      <example>
-                        <title>Three-part Compound Inequality (Negative Coefficient)</title>
-                          <!-- Modeled after our WeBWorK-->
-                        <p>Solve the compound inequality, graph the solution, and express it in both inequality and interval notation.
-                          <sidebyside widths="40% 55%" valign="middle">
-                            <paragraphs>
-                              <p><m>-3\lt 7-2x \leq -1</m></p>
-                              <p>The inequality requires the expression <m>\color{blue}{7-2x}</m> to lie in the interval <m>(-3,-1]</m></p>
-                            </paragraphs>
- <!--                           <figure xml:id="figure-inequality-solution-neg3-leq-7-2x-lt-neg1">  -->
-                              <image xml:id="inequality-solution-neg3-leq-7-2x-lt-neg1">
-                                <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=blue] (-3,.5) circle (.1cm); \fill[color=blue] (-1,.5) circle (.1cm); \draw[blue] (-2.9,.5) -- (-1,.5); \node[anchor=south, color=blue] at (-2,.5) {$7-2x$}; \end{tikzpicture} ]]></latex-image-code>
-                                </image>
- <!--                             </figure>  -->
-                            </sidebyside>
-                          <md>
-                            <mrow>-3\lt 7-2x \leq -1 \amp\amp\amp \text{Subtract \(7\) from all three parts of the compound inequality}</mrow>
-                            <mrow>\underline{-7\phantom{1}-7\phantom{1234}-7} \amp\amp\amp \,</mrow>
-                            <mrow>-10\lt -2x \leq -8 \amp\amp\amp \text{Divide all three parts by \(-2\):
-                              FLIP SIGNS}
-                            </mrow>
-                            <mrow>\overline{ -2 }\phantom{123}\overline{ -2 }\phantom{1234}\overline{ -2 } \amp\amp\amp \,</mrow>
-                          </md>
-                          <sidebyside widths="20% 20% 55%" valign="middle">
-                            <p></p>
-                            <p><m>5\gt \color{red}{x}\geq 4</m></p>
- <!--                           <figure xml:id="figure-inequality-solution-4-leq-x-lt-5">  -->
-                              <image xml:id="inequality-solution-4-leq-x-lt-5">
-                                <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
-                                  <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=red] (4,.5) circle (.1cm); \draw[color=red] (5,.5) circle (.1cm); \draw[red] (4,.5) -- (4.9,.5); \node[anchor=south, color=red] at (4.5,.5) {$x$}; \end{tikzpicture} ]]></latex-image-code>
-                                </image>
- <!--                             </figure>  -->
-                            </sidebyside>
-                            <md>
-                              <mrow>4\leq x \lt 5 \amp\amp\amp \text{Our Solution: Inequality Notation}\checkmark</mrow>
-                              <mrow>[4,5) \amp\amp\amp \text{Our Solution: Interval Notation}\checkmark</mrow>
-                            </md>
-                          </p>
-                          </example>
-                        </subsection>
+                      <image xml:id="inequality-solution-zero-leq-x-lt-3">
+                        <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+                          <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=red] (0,.5) circle (.1cm); \draw[color=red] (3,.5) circle (.1cm); \draw[red] (0,.5) -- (2.9,.5); \node[anchor=south, color=red] at (1.5,.5) {$x$}; \end{tikzpicture} ]]>
+                        </latex-image-code>
+                      </image>
+                    </sidebyside>
+                    <p>
+                      <md>
+                        <mrow>0\leq x \lt 3 \amp\amp\amp \text{Our Solution: Inequality Notation}\checkmark</mrow>
+                        <mrow>[0,3) \amp\amp\amp \text{Our Solution: Interval Notation}\checkmark</mrow>
+                      </md>
+                    </p>
+                  </example>
+                  <example>
+                  <title>Three-part Compound Inequality (Negative Coefficient)</title>
+                    <!-- Modeled after our WeBWorK-->
+                  <p>Solve the compound inequality, graph the solution, and express it in both inequality and interval notation.</p>
+                  <sidebyside widths="40% 55%" valign="middle">
+                    <paragraphs>
+                      <p><m>-3\lt 7-2x \leq -1</m></p>
+                      <p>The inequality requires the expression <m>\color{blue}{7-2x}</m> to lie in the interval <m>(-3,-1]</m></p>
+                    </paragraphs>
+                    <image xml:id="inequality-solution-neg3-leq-7-2x-lt-neg1">
+                      <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+                        <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=blue] (-3,.5) circle (.1cm); \fill[color=blue] (-1,.5) circle (.1cm); \draw[blue] (-2.9,.5) -- (-1,.5); \node[anchor=south, color=blue] at (-2,.5) {$7-2x$}; \end{tikzpicture} ]]>
+                      </latex-image-code>
+                    </image>
+                  </sidebyside>
+                  <p>
+                    <md>
+                      <mrow>-3\lt 7-2x \leq -1 \amp\amp\amp \text{Subtract \(7\) from all three parts of the compound inequality}</mrow>
+                      <mrow>\underline{-7\phantom{1}-7\phantom{1234}-7} \amp\amp\amp \,</mrow>
+                      <mrow>-10\lt -2x \leq -8 \amp\amp\amp \text{Divide all three parts by \(-2\):
+                        FLIP SIGNS}
+                      </mrow>
+                      <mrow>\overline{ -2 }\phantom{123}\overline{ -2 }\phantom{1234}\overline{ -2 } \amp\amp\amp \,</mrow>
+                    </md>
+                  </p>
+                  <sidebyside widths="20% 20% 55%" valign="middle">
+                    <p></p>
+                    <p><m>5\gt \color{red}{x}\geq 4</m></p>
+<!--                           <figure xml:id="figure-inequality-solution-4-leq-x-lt-5">  -->
+                    <image xml:id="inequality-solution-4-leq-x-lt-5">
+                      <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+                          <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=red] (4,.5) circle (.1cm); \draw[color=red] (5,.5) circle (.1cm); \draw[red] (4,.5) -- (4.9,.5); \node[anchor=south, color=red] at (4.5,.5) {$x$}; \end{tikzpicture} ]]>
+                      </latex-image-code>
+                    </image>
+                  </sidebyside>
+                  <p>
+                    <md>
+                      <mrow>4\leq x \lt 5 \amp\amp\amp \text{Our Solution: Inequality Notation}\checkmark</mrow>
+                      <mrow>[4,5) \amp\amp\amp \text{Our Solution: Interval Notation}\checkmark</mrow>
+                    </md>
+                  </p>
+                </example>
+              </subsection>
 <subsection>
 <title>Absolute Value Inequalities</title>
 <!-- THIS HAS BEEN CHANGED QUITE A BIT.  WHAT IS LEFT FROM WALLACE'S TEXT? Cite Beginning and Intermediate Algebra by Tyler Wallace is licensed under a Creative Commons Attribution 3.0 Unported License. (http://creativecommons.org/licenses/by/3.0/) Based on a work at http://wallace.ccfaculty.org/book/book.html. pages 128-131-->
@@ -344,20 +341,18 @@
 </md>
 </p>
 <p>Absolute value is defined as distance from zero. This inequality may be interpreted as all values which are
-<b>less</b> than
+<term>less</term> than
 <m>2</m> units from zero. On the number line, shown below, all values
-<b>less than</b>
+<term>less than</term>
 <m>2</m> units away from zero are indicated.
 </p>
-<p align="center">
-<!--<figure xml:id="figure-absolute-value-x-lt-2">-->
-<image xml:id="absolute-value-x-lt-2">
+<sidebyside>
+  <image xml:id="absolute-value-x-lt-2">
   <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
     <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=blue] (-2,.5) circle (.1cm); \draw[color=blue] (2,.5) circle (.1cm); \draw[blue] (-1.9,.5) -- (1.9,.5); \node[anchor=south, color=blue] at (0,.5) {$-2
       <x<2$}; \end{tikzpicture} ]]></latex-image-code>
     </image>
- <!-- </figure>  -->
-</p>
+</sidebyside>
 <p>This graph looks just like the graphs of the three part compound inequalities! When the absolute value is less than a positive number we will determine the solutions to the inequality by changing the problem to a three-part inequality, with the negative value on the "lesser than end" and the positive value on the "greater than end":
   <md>
     <mrow>\lvert x\rvert  \lt 2 \text{ is equivalent to  } \color{blue}{-2 \lt x \lt 2}</mrow>
@@ -368,28 +363,26 @@
 <mrow>\lvert x\rvert \gt 2.</mrow>
 </md>
 </p>
-<p>Keep in mind, absolute value is defined as distance from zero. This inequality represents the values which are  
-  <b>greater</b> than
+<p>Keep in mind, absolute value is defined as distance from zero. This inequality represents the values which are
+  <term>greater</term> than
   <m>2</m> units away from zero. On the number line below we shade all points that are
-  <b>more than</b>
+  <term>more than</term>
   <m>2</m> units away from zero.
 </p>
-<p align="center">
-<!--  <figure xml:id="figure-absolute-value-x-gt-2">  -->
+<sidebyside>
     <image xml:id="absolute-value-x-gt-2">
       <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
         <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=red] (-2,.5) circle (.1cm); \draw[red,
           <-] (-5.5,.5) -- (-2.1,.5); \node[anchor=south, color=red] at (-4,.5) {$x<-2$}; \draw[color=blue] (2,.5) circle (.1cm); \draw[blue, ->] (2.1,.5) -- (5.5,.5); \node[anchor=south, color=blue] at (4,.5) {$x>2$}; \end{tikzpicture} ]]></latex-image-code>
         </image>
-<!--      </figure>  -->
-    </p>
+</sidebyside>
     <p>When the absolute value is greater than a positive number we find the solution by rewriting the absolute value inequality as two inequalities.  The first inequality is used to determine the solutions greater than the positive number, the second inequality yields the solutions which are less than the negative of the number:
       <md>
         <mrow>\lvert x\rvert  \gt 2 \text{ is equivalent to  } \color{blue}{x\gt 2} \text{ or }\color{red}{ x \lt -2}</mrow>
       </md>as the graph above illustrates.
     </p>
     <p>The solution to an absolute value inequality may also be expressed in interval notation.  There is a special symbol to represent the "OR" when two intervals are required.  It's called the
-      <b>union</b>:
+      <term>union</term>:
       <m>\cup.</m> We will learn more about unions in <xref ref="section-4A-sets-and-counting" autoname="yes" />.
     </p>
     <assemblage>
@@ -407,30 +400,37 @@
     </assemblage>
     <p>We can solve absolute value inequalities much like we solved absolute value equations.
     </p>
-    <!--  <ol>-->
     <aside>
-      <p>To solve an absolute value inequality:</p>
-        <p>1."Remove" the absolute value</p>
-      <ul>
-          <li>If
-            <m>\lvert \text{expression}\rvert \lt p</m> is
-            <term>less than a positive number</term> make a three part inequality:
-            <m>-p\lt \text{expression}\lt p</m>
-          </li>
-          <li>If
-            <m>\lvert \text{expression}\rvert \gt p</m> is
-            <term>greater than a positive number</term> make an OR inequality:
-            <m>\text{expression}\lt -p</m> or
-            <m>\text{expression}\gt p</m>
-          </li>
-       </ul>
-        <p>2. Solve the inequalities</p>
-       <ul>
+      <p>To solve an absolute value inequality:
+        <ol>
           <li>
-            <term>Important:</term> if we multiply or divide by a negative number the inequality symbol will switch directions!
+            <p>"Remove" the absolute value
+              <ul>
+                <li>If
+                  <m>\lvert \text{expression}\rvert \lt p</m> is
+                  <term>less than a positive number</term> make a three part inequality:
+                  <m>-p\lt \text{expression}\lt p</m>
+                </li>
+                <li>If
+                  <m>\lvert \text{expression}\rvert \gt p</m> is
+                  <term>greater than a positive number</term> make an OR inequality:
+                  <m>\text{expression}\lt -p</m> or
+                  <m>\text{expression}\gt p</m>
+                </li>
+              </ul>
+            </p>
           </li>
-       </ul>
-      <!--</ol>-->
+          <li>
+            <p>Solve the inequalities
+              <ul>
+                <li>
+                  <term>Important:</term> if we multiply or divide by a negative number the inequality symbol will switch directions!
+                </li>
+              </ul>
+            </p>
+          </li>
+        </ol>
+      </p>
     </aside>
     <example>
       <title>Absolute Value Inequality: Less than</title>
@@ -442,34 +442,34 @@
           <mrow>\underline{+2\phantom{12345}+2\phantom{1}+2} \amp\amp\amp \,</mrow>
           <mrow>-1 \lt x \lt 5 \amp\amp\amp \text{Graph}</mrow>
         </md>
-        <sidebyside widths="55% 40%" valign="middle">
-<!--          <figure xml:id="figure-absolute-value-neg1-lt-x-lt-5">  -->
-            <image xml:id="absolute-value-neg1-lt-x-lt-5">
-              <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) -- (5.5,0); 
-                  \foreach \x in {-5,...,5} 
+      </p>
+      <sidebyside widths="55% 40%" valign="middle">
+        <image xml:id="absolute-value-neg1-lt-x-lt-5">
+          <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) -- (5.5,0);
+                  \foreach \x in {-5,...,5}
                   \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x};
-                  \draw (2,.4) -- (2,.6); 
-                  \draw[color=M101_green] (-1,.5) circle (.1cm); 
-                  \draw[color=M101_green] (5,.5) circle (.1cm); 
-                  \draw[M101_green] (-.9,.5) -- (4.9,.5);  
-                  \node[anchor=south, color=M101_green] at (2,.5) {$-1 < x < 5$}; \end{tikzpicture}]]></latex-image-code>
-                </image>
- <!--             </figure>  -->
-              <paragraphs>
-                <p>Our Graph
-                  <m>\checkmark</m>
-                </p>
-                <p>Interval notation:
-                  <m>(-1,5)\checkmark</m>
-                </p>
-              </paragraphs>
-            </sidebyside>
-          Note that the values described in the absolute value inequality <m>\lvert x-2\rvert \color{red}{\lt} 3</m> are all the values which are within
+                  \draw (2,.4) -- (2,.6);
+                  \draw[color=M101_green] (-1,.5) circle (.1cm);
+                  \draw[color=M101_green] (5,.5) circle (.1cm);
+                  \draw[M101_green] (-.9,.5) -- (4.9,.5);
+                  \node[anchor=south, color=M101_green] at (2,.5) {$-1 < x < 5$}; \end{tikzpicture}]]>
+          </latex-image-code>
+        </image>
+        <paragraphs>
+          <p>Our Graph
+            <m>\checkmark</m>
+          </p>
+          <p>Interval notation:
+            <m>(-1,5)\checkmark</m>
+          </p>
+        </paragraphs>
+      </sidebyside>
+      <p>Note that the values described in the absolute value inequality <m>\lvert x-2\rvert \color{red}{\lt} 3</m> are all the values which are within
             <m>3</m> units of
             <m>2.</m>
-          </p>
-        </example>
-        <example>
+      </p>
+    </example>
+    <example>
       <title>Distance (Three-Part Inequality)</title>
       <!-- Our own like WeBWorK 1C Problem 18-->
       <p>Suppose the distance between
@@ -477,7 +477,7 @@
         <m>6</m>. Determine
         <m>x.</m>
       </p>
-      <p>Start by translating the words into an equation.  We will need to translate <term>distance</term> into absolute value. We are given 
+      <p>Start by translating the words into an equation.  We will need to translate <term>distance</term> into absolute value. We are given
           <ul>
             <li><m>x=</m> the <term>unknown</term> number(s)</li>
             <li>the distance is less than or equal to <m>6</m></li>
@@ -505,35 +505,35 @@
               <mrow>\underline{-1\phantom{1}-1}\amp\phantom{123456}\underline{-1\phantom{1}-1} \amp\amp \text{Subtract \(1\) from both sides of each inequality}</mrow>
               <mrow>\color{red}{x\leq -4}\amp\text{  OR  }\phantom{1234}\color{blue}{x\geq 2} \amp\amp \text{Graph the solutions}</mrow>
             </md>
-            <sidebyside widths="55% 40%" valign="middle">
-<!--              <figure xml:id="figure-absolute-value-x-plus-1-geq-3">  -->
-                <image xml:id="absolute-value-x-plus-1-geq-3">
-                  <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) -- (5.5,0); 
-    \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; 
-    \fill[color=red] (-4,.5) circle (.1cm); 
-    \draw[red,<-] (-5.5,.5) -- (-3.9,.5); 
-    \node[anchor=south, color=red] at (-4.75,.5) {$x\leq -4$}; 
-    \fill[color=blue] (2,.5) circle (.1cm); 
-    \draw[blue, ->] (2.1,.5) -- (5.5,.5); 
-    \node[anchor=south, color=blue] at (4,.5) {$x\geq 2$}; \end{tikzpicture} ]]>
-                    </latex-image-code>
-                  </image>
-<!--                </figure>  -->
-              <paragraphs>
-                <p>Our Graph
-                  <m>\checkmark</m>
-                </p>
-                <p>Interval notation:</p>
-                <p>
-                  <m>\left(-\infty,-4\right]\cup\left[2,\infty\right)\checkmark</m>
-                </p>
-              </paragraphs>
-            </sidebyside>
+          </p>
+          <sidebyside widths="55% 40%" valign="middle">
+            <image xml:id="absolute-value-x-plus-1-geq-3">
+              <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) -- (5.5,0);
+              \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x};
+              \fill[color=red] (-4,.5) circle (.1cm);
+              \draw[red,<-] (-5.5,.5) -- (-3.9,.5);
+              \node[anchor=south, color=red] at (-4.75,.5) {$x\leq -4$};
+              \fill[color=blue] (2,.5) circle (.1cm);
+              \draw[blue, ->] (2.1,.5) -- (5.5,.5);
+              \node[anchor=south, color=blue] at (4,.5) {$x\geq 2$}; \end{tikzpicture} ]]>
+              </latex-image-code>
+            </image>
+            <paragraphs>
+              <p>Our Graph
+                <m>\checkmark</m>
+              </p>
+              <p>Interval notation:</p>
+              <p>
+                <m>\left(-\infty,-4\right]\cup\left[2,\infty\right)\checkmark</m>
+              </p>
+            </paragraphs>
+          </sidebyside>
+          <p>
              In this case, the absolute value inequality <m>\lvert x+1 \rvert \geq 3</m> describes all the values which are more than
                 <m>3</m> units away from
                 <m>-1</m>.
               </p>
-            </example>
+          </example>
             <p>In the next example, we will work backwards to find a description for a distance.</p>
             <example>
               <title>Denote Distance With an Absolute Value</title>
@@ -567,7 +567,7 @@
         <m>3</m>. Determine
         <m>x</m>.
       </p>
-      <p>Start by translating the words into an equation.  We will need to translate <term>distance</term> into absolute value. We are given 
+      <p>Start by translating the words into an equation.  We will need to translate <term>distance</term> into absolute value. We are given
           <ul>
             <li><m>x=</m> the <term>unknown</term> number(s)</li>
             <li>the distance is greater than <m>3</m></li>
@@ -604,15 +604,14 @@
           <mrow>4x\leq -1\amp\text{ OR }\phantom{123} 4x\geq 11 \amp\amp \text{Divide both sides by \(4\)}</mrow>
           <mrow>\overline{4}\phantom{1234}\overline{4}\amp\phantom{1234567}\overline{4}\phantom{12345}\overline{4} \amp\amp </mrow>
           <mrow>\color{blue}{x\leq -\dfrac{1}{4}}\amp\text{ OR }\phantom{1234}\color{red}{x\geq \dfrac{11}{4}} \amp\amp \text{Graph the solutions}</mrow>
-          </md>      
-          <sidebyside widths="55% 40%" valign="middle">
-<!--          <figure xml:id="figure-absolute-value-4x-5-geq-6">  -->
+          </md>
+        </p>
+        <sidebyside widths="55% 40%" valign="middle">
           <image xml:id="absolute-value-4x-5-geq-6">
             <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
             <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \fill[color=red] (-.25,.5) circle (.1cm); \draw[red,
               <-] (-5.5,.5) -- (-.35,.5); \node[anchor=south, color=red] at (-3,.5) {$x\leq -\frac{1}{4}$}; \fill[color=blue] (2.75,.5) circle (.1cm); \draw[blue, ->] (2.85,.5) -- (5.5,.5); \node[anchor=south, color=blue] at (4,.5) {$x\geq\frac{11}{4}$}; \end{tikzpicture} ]]></latex-image-code>
            </image>
-<!--           </figure>  -->
            <paragraphs>
               <p>Our Graph
               <m>\checkmark</m>
@@ -622,8 +621,7 @@
                <m>\left(-\infty,-\dfrac{1}{4}\right]\cup\left[\dfrac{11}{4},\infty\right)\checkmark</m>
                </p>
             </paragraphs>
-            </sidebyside>
-        </p>
+          </sidebyside>
       </example>
       <example>
           <title>Absolute Value Inequality</title>
@@ -639,26 +637,25 @@
               <mrow>\color{green}{2\gt x \gt -1} \amp\amp\amp \text{Rewrite the inequality (not a necessary step)}</mrow>
               <mrow>\color{green}{-1\lt x \lt 2} \amp\amp\amp \text{Graph}</mrow>
             </md>
-            <sidebyside widths="55% 40%" valign="middle">
- <!--             <figure xml:id="figure-absolute-value-neg1-lt-x-lt-2">  -->
-                <image xml:id="absolute-value-neg1-lt-x-lt-2">
-                  <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
+          </p>
+          <sidebyside widths="55% 40%" valign="middle">
+            <image xml:id="absolute-value-neg1-lt-x-lt-2">
+              <latex-image-code><![CDATA[\begin{tikzpicture} \draw[
                     <->] (-5.5,0) -- (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) -- (\x, -0.1) node [below] {\x}; \draw[color=M101_green] (-1,.5) circle (.1cm); \draw[color=M101_green] (2,.5) circle (.1cm); \draw[M101_green] (-.9,.5) -- (1.9,.5); \node[anchor=south, color=M101_green] at (.5,.5) {$-1
-                      < x < 2$}; \end{tikzpicture} ]]></latex-image-code>
-                    </image>
- <!--                 </figure>  -->
-                <paragraphs>
-                    <p>Our Graph
-                      <m>\checkmark</m>
-                    </p>
-                    <p>Interval notation:</p>
-                    <p>
-                      <m>\left(-1,2\right)\checkmark</m>
-                    </p>
-                </paragraphs>
-              </sidebyside>
-            </p>
-        </example>    
+                      < x < 2$}; \end{tikzpicture} ]]>
+              </latex-image-code>
+            </image>
+            <paragraphs>
+                <p>Our Graph
+                  <m>\checkmark</m>
+                </p>
+                <p>Interval notation:</p>
+                <p>
+                  <m>\left(-1,2\right)\checkmark</m>
+                </p>
+            </paragraphs>
+          </sidebyside>
+        </example>
        <p>Recall that there are two special cases when solving absolute value equations.  We must consider them for inequalities as well.</p>
       <example>
         <title>Absolute Value is Always Greater than a Negative</title>
@@ -673,8 +670,8 @@
         </md>
       </p>
       </example>
-      <p>Notice in the example above, the absolute value expression is always greater than a negative number.  What if the inequality involved a "less than"? 
-      </p> 
+      <p>Notice in the example above, the absolute value expression is always greater than a negative number.  What if the inequality involved a "less than"?
+      </p>
       <example>
         <title>Absolute Value With a Less Than a Negative</title>
         <p> <!-- COue own-->
@@ -699,7 +696,7 @@
           <mrow>\lvert x-3\rvert \lt 0 \amp\amp\amp \text{Can an absolute value be less than zero?}</mrow>
           <mrow>\text{No solution} \amp\amp\amp \text{Nope }\checkmark</mrow>
           <mrow> \amp\amp\amp </mrow>
-          <mrow>\text{How about the other way?} \amp\amp\amp </mrow>  
+          <mrow>\text{How about the other way?} \amp\amp\amp </mrow>
           <mrow> \amp\amp\amp </mrow>
           <mrow>\lvert 2x+ 1\rvert \ge 0\amp\amp\amp \text{Absolute values are always greater or equal to zero}</mrow>
           <mrow>\amp\amp\amp\text{Any value of \(x\) will work (try a few!)}</mrow>
@@ -707,6 +704,6 @@
         </md>
       </p>
       </example>
-            <!--THESE REQUIRE SIMPLIFYING THE EXPRESSION FIRST##MOVE TO MAT-102? <example> <title>Absolute Value Inequality: OR inequality</title> <p>Solve, graph, and give interval notation for the solution. <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 161 pg 130**> </p> <p> <md> <mrow>-4-3\lvert x\rvert \leq -16 \amp\amp\amp \text{Isolate the absolute value: Add \(4\) to both sides } </mrow> <mrow>\underline{+4\phantom{123456789}+4} \amp\amp\amp \, </mrow> <mrow>-3\lvert x\rvert \leq -12 \amp\amp\amp \text{Divide both sides by negative 3} </mrow> <mrow>\overline{-3}\phantom{123456}\overline{-3} \amp\amp\amp \text{Dividing by a negative switches the inequality direction} </mrow> <mrow>\lvert x\rvert \color{red}{\geq} 4 \amp\amp\amp \text{Absolute value is greater, use OR} </mrow> <mrow>\color{blue}{x\geq 4}\) OR \(\color{red}{x\leq -4} \amp\amp\amp \text{Graph} </mrow></md> <p align="center"> <figure xml:id="figure-absolute-value-4-3absx-leq-16"> <image xml:id="absolute-value-4-3absx-leq-16"> <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) ## (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) ## (\x, -0.1) node [below] {\x}; \fill[color=red] (-4,.5) circle (.1cm); \draw[red, <-] (-5.5,.5) ## (-4,.5); \node[anchor=south, color=red] at (-4.75,.5) {$x\leq -4$}; \fill[color=blue] (4,.5) circle (.1cm); \draw[blue, ->] (4,.5) ## (5.5,.5); \node[anchor=south, color=blue] at (4.75,.5) {$x\geq 4$}; \end{tikzpicture} ]]></latex-image-code> </image> </figure> </p><p>Our graph</p> <md> <mrow>(-\infty,-4]\cup[4,\infty) \amp\amp\amp \text{Interval notation} </mrow> </md> </p> </example> <p>In the previous example, we cannot combine <m>-4</m> and <m>-3</m> because they are not like terms, the <m>-3</m> has an absolute value term attached. So we must first clear the <m>-4</m> by adding <m>4</m>, then divide by <m>-3</m>. The next example is similar. </p> <example> <title>Absolute Value Inequality: OR inequality</title> <p>Solve, graph, and give interval notation for the solution. <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 162 pg 131**> </p> <p> <md> <mrow>9-2|4x+1|\gt 3 \amp\amp\amp \text{Subtract \(9\) from both sides } </mrow> <mrow>\underline{-9\phantom{12345678910}-9} \amp\amp\amp \, </mrow> <mrow>-2|4x+1|\gt -6 \amp\amp\amp \text{Divide both sides by \(-2\)} </mrow> <mrow>\overline{-2}\phantom{123456789}\overline{-2} \amp\amp\amp \text{Dividing by a negative switches the inequality direction} </mrow> <mrow>|4x+1|\color{red}{\lt} 3 \amp\amp\amp \text{Absolute value is less, use three part inequality} </mrow> <mrow>-3\lt 4x+1\lt 3 \amp\amp\amp \text{Subtract 1 from all three parts} </mrow> <mrow>\underline{-1\phantom{12345}-1\phantom{1}-1} \amp\amp\amp \, </mrow> <mrow>-4\lt 4x \lt 2 \amp\amp\amp \text{Divide all three parts by \(4\)} </mrow> <mrow>\overline{4}\phantom{123}\overline{4}\phantom{123}\overline{4} \amp\amp\amp \, </mrow> <mrow>\color{green}{-1\lt x \lt\dfrac{1}{2}} \amp\amp\amp \text{Graph} </mrow> </md> <p align="center"> <figure xml:id="figure-absolute-value-neg1-lt-x-lt-half"> <image xml:id="absolute-value-neg1-lt-x-lt-half"> <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) ## (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) ## (\x, -0.1) node [below] {\x}; \draw[color=M101_green] (-1,.5) circle (.1cm); \draw[color=M101_green] (.5,.5) circle (.1cm); \draw[M101_green] (-.9,.5) ## (.4,.5); \node[anchor=south, color=M101_green] at (-.35,.5) {$-1 < x <\frac{1}{2}$}; \end{tikzpicture} ]]></latex-image-code> </image> </figure> </p><p>Our graph</p> <md> <mrow>\left(-1,\dfrac{1}{2}\right) \amp\amp\amp \text{Interval notation} </mrow> </md> </p> </example> <p>In the previous example, we cannot distribute the <m>-2</m> into the absolute value. We can never distribute or combine things outside the absolute value with what is inside the absolute value. Our only way to solve is to first isolate the absolute value by clearing the values around it, then either make a compound inequality (an OR or a three part) to solve. </p> <p>It is important to remember as we are solving these equations, the absolute value is always positive. If we end up with an absolute value less than a negative number, then we will have no solution! Similarly, if we end up with an absolute value greater than a negative, this will always happen. Here the answer will be all real numbers.</p> <example> <title>Absolute Value Less than Negative Number</title> <p>Solve, graph, and give interval notation for the solution.</p> <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 163 pg 131**> <p> <md> <mrow>12+4|6x-1|\lt 4 \amp\amp\amp \text{Subtract \(12\) from both sides } </mrow> <mrow>\underline{-12\phantom{123456789}-12} \amp\amp\amp \, </mrow> <mrow>4\lvert 6x-1\rvert \lt -8 \amp\amp\amp \text{Divide both sides by \(4\)} </mrow> <mrow>\overline{4}\phantom{12345678910}\overline{4} \amp\amp\amp \text{Dividing by a positive: DON'T switch the inequality direction} </mrow> <mrow>\lvert 6x-1\rvert \lt -2 \amp\amp\amp \text{<font color="#FF0000"/> STOP:Absolute value can't be less than a negative! } </mrow> <mrow>\text{No solution} \amp\amp\amp \text{Our Solution}</mrow> </md> </p> </example> <example> <title>Absolute Value Greater than Negative Number</title> <p>Solve, graph, and give interval notation for the solution. <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 164 pg 131**> </p> <p> <md> <mrow>5-6|x+7|\leq 17 \amp\amp\amp \text{Subtract \(5\) from both sides } </mrow> <mrow>\underline{-5\phantom{123456789}-5} \amp\amp\amp \, </mrow> <mrow>-6\lvert x+7\rvert \leq 12 \amp\amp\amp \text{Divide both sides by \(-6\)} </mrow> <mrow>\overline{-6}\phantom{12345678910}\overline{-6} \amp\amp\amp \text{Dividing by a negative switches the inequality direction} </mrow> <mrow>\lvert x+7\rvert \color{red}{\geq} -2 \amp\amp\amp \text{Absolute value <b>always</b> greater than negative! } </mrow> <mrow>x\) can be any real number: \(-\infty\lt x \lt\infty\) or \(\phantom{1234} \amp\amp\amp \text{Our Solution: Inequality notation} </mrow> <mrow>(-\infty, \infty) \amp\amp\amp \text{Our Solution: Interval notation} </mrow> </md> </p> </example> -->
+            <!--THESE REQUIRE SIMPLIFYING THE EXPRESSION FIRST##MOVE TO MAT-102? <example> <title>Absolute Value Inequality: OR inequality</title> <p>Solve, graph, and give interval notation for the solution. <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 161 pg 130**> </p> <p> <md> <mrow>-4-3\lvert x\rvert \leq -16 \amp\amp\amp \text{Isolate the absolute value: Add \(4\) to both sides } </mrow> <mrow>\underline{+4\phantom{123456789}+4} \amp\amp\amp \, </mrow> <mrow>-3\lvert x\rvert \leq -12 \amp\amp\amp \text{Divide both sides by negative 3} </mrow> <mrow>\overline{-3}\phantom{123456}\overline{-3} \amp\amp\amp \text{Dividing by a negative switches the inequality direction} </mrow> <mrow>\lvert x\rvert \color{red}{\geq} 4 \amp\amp\amp \text{Absolute value is greater, use OR} </mrow> <mrow>\color{blue}{x\geq 4}\) OR \(\color{red}{x\leq -4} \amp\amp\amp \text{Graph} </mrow></md> <p> <figure xml:id="figure-absolute-value-4-3absx-leq-16"> <image xml:id="absolute-value-4-3absx-leq-16"> <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) ## (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) ## (\x, -0.1) node [below] {\x}; \fill[color=red] (-4,.5) circle (.1cm); \draw[red, <-] (-5.5,.5) ## (-4,.5); \node[anchor=south, color=red] at (-4.75,.5) {$x\leq -4$}; \fill[color=blue] (4,.5) circle (.1cm); \draw[blue, ->] (4,.5) ## (5.5,.5); \node[anchor=south, color=blue] at (4.75,.5) {$x\geq 4$}; \end{tikzpicture} ]]></latex-image-code> </image> </figure> </p><p>Our graph</p> <md> <mrow>(-\infty,-4]\cup[4,\infty) \amp\amp\amp \text{Interval notation} </mrow> </md> </p> </example> <p>In the previous example, we cannot combine <m>-4</m> and <m>-3</m> because they are not like terms, the <m>-3</m> has an absolute value term attached. So we must first clear the <m>-4</m> by adding <m>4</m>, then divide by <m>-3</m>. The next example is similar. </p> <example> <title>Absolute Value Inequality: OR inequality</title> <p>Solve, graph, and give interval notation for the solution. <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 162 pg 131**> </p> <p> <md> <mrow>9-2|4x+1|\gt 3 \amp\amp\amp \text{Subtract \(9\) from both sides } </mrow> <mrow>\underline{-9\phantom{12345678910}-9} \amp\amp\amp \, </mrow> <mrow>-2|4x+1|\gt -6 \amp\amp\amp \text{Divide both sides by \(-2\)} </mrow> <mrow>\overline{-2}\phantom{123456789}\overline{-2} \amp\amp\amp \text{Dividing by a negative switches the inequality direction} </mrow> <mrow>|4x+1|\color{red}{\lt} 3 \amp\amp\amp \text{Absolute value is less, use three part inequality} </mrow> <mrow>-3\lt 4x+1\lt 3 \amp\amp\amp \text{Subtract 1 from all three parts} </mrow> <mrow>\underline{-1\phantom{12345}-1\phantom{1}-1} \amp\amp\amp \, </mrow> <mrow>-4\lt 4x \lt 2 \amp\amp\amp \text{Divide all three parts by \(4\)} </mrow> <mrow>\overline{4}\phantom{123}\overline{4}\phantom{123}\overline{4} \amp\amp\amp \, </mrow> <mrow>\color{green}{-1\lt x \lt\dfrac{1}{2}} \amp\amp\amp \text{Graph} </mrow> </md> <p> <figure xml:id="figure-absolute-value-neg1-lt-x-lt-half"> <image xml:id="absolute-value-neg1-lt-x-lt-half"> <latex-image-code><![CDATA[\begin{tikzpicture} \draw[<->] (-5.5,0) ## (5.5,0); \foreach \x in {-5,...,5} \draw (\x, 0.1) ## (\x, -0.1) node [below] {\x}; \draw[color=M101_green] (-1,.5) circle (.1cm); \draw[color=M101_green] (.5,.5) circle (.1cm); \draw[M101_green] (-.9,.5) ## (.4,.5); \node[anchor=south, color=M101_green] at (-.35,.5) {$-1 < x <\frac{1}{2}$}; \end{tikzpicture} ]]></latex-image-code> </image> </figure> </p><p>Our graph</p> <md> <mrow>\left(-1,\dfrac{1}{2}\right) \amp\amp\amp \text{Interval notation} </mrow> </md> </p> </example> <p>In the previous example, we cannot distribute the <m>-2</m> into the absolute value. We can never distribute or combine things outside the absolute value with what is inside the absolute value. Our only way to solve is to first isolate the absolute value by clearing the values around it, then either make a compound inequality (an OR or a three part) to solve. </p> <p>It is important to remember as we are solving these equations, the absolute value is always positive. If we end up with an absolute value less than a negative number, then we will have no solution! Similarly, if we end up with an absolute value greater than a negative, this will always happen. Here the answer will be all real numbers.</p> <example> <title>Absolute Value Less than Negative Number</title> <p>Solve, graph, and give interval notation for the solution.</p> <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 163 pg 131**> <p> <md> <mrow>12+4|6x-1|\lt 4 \amp\amp\amp \text{Subtract \(12\) from both sides } </mrow> <mrow>\underline{-12\phantom{123456789}-12} \amp\amp\amp \, </mrow> <mrow>4\lvert 6x-1\rvert \lt -8 \amp\amp\amp \text{Divide both sides by \(4\)} </mrow> <mrow>\overline{4}\phantom{12345678910}\overline{4} \amp\amp\amp \text{Dividing by a positive: DON'T switch the inequality direction} </mrow> <mrow>\lvert 6x-1\rvert \lt -2 \amp\amp\amp \text{<font color="#FF0000"/> STOP:Absolute value can't be less than a negative! } </mrow> <mrow>\text{No solution} \amp\amp\amp \text{Our Solution}</mrow> </md> </p> </example> <example> <title>Absolute Value Greater than Negative Number</title> <p>Solve, graph, and give interval notation for the solution. <!** Modeled after Beginning and Intermediate Algebra by Tyler Wallace Example 164 pg 131**> </p> <p> <md> <mrow>5-6|x+7|\leq 17 \amp\amp\amp \text{Subtract \(5\) from both sides } </mrow> <mrow>\underline{-5\phantom{123456789}-5} \amp\amp\amp \, </mrow> <mrow>-6\lvert x+7\rvert \leq 12 \amp\amp\amp \text{Divide both sides by \(-6\)} </mrow> <mrow>\overline{-6}\phantom{12345678910}\overline{-6} \amp\amp\amp \text{Dividing by a negative switches the inequality direction} </mrow> <mrow>\lvert x+7\rvert \color{red}{\geq} -2 \amp\amp\amp \text{Absolute value <b>always</b> greater than negative! } </mrow> <mrow>x\) can be any real number: \(-\infty\lt x \lt\infty\) or \(\phantom{1234} \amp\amp\amp \text{Our Solution: Inequality notation} </mrow> <mrow>(-\infty, \infty) \amp\amp\amp \text{Our Solution: Interval notation} </mrow> </md> </p> </example> -->
           </subsection>
         </section>

--- a/src/set2C_Applications.mbx
+++ b/src/set2C_Applications.mbx
@@ -1,19 +1,21 @@
 <section xml:id="section-2C-applications">
   <title>Applications</title>
   <introduction>
-    <ul>
-      <li>Solve number problems by creating and solving an equation.</li>
-      <li>Solve problems using scientific notation and exponent properties.</li>
-      <li>Solve formulas for a given variable.</li>
-      <li>Solve practical percent problems.</li>
-      <li>Solve weighted average problems.</li>
-      <li>Interpret plus or minus notation for intervals.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Solve number problems by creating and solving an equation.</li>
+        <li>Solve problems using scientific notation and exponent properties.</li>
+        <li>Solve formulas for a given variable.</li>
+        <li>Solve practical percent problems.</li>
+        <li>Solve weighted average problems.</li>
+        <li>Interpret plus or minus notation for intervals.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Linear Equation Applications</title>
     <p>Applications often involve converting an English sentence into a mathematical sentence. These first examples will focus on basic number problems to build your skills at "translating" words into math symbols.</p>
-    <p>A few important phrases can give us clues for how to set up a problem.</p>
+    <p>A few important phrases can give us clues for how to set up a problem.
     <ul>
       <li><p>
         <term>A number</term> (or <term>an unknown</term>, <term>a value</term>, etc) usually becomes our variable
@@ -28,7 +30,7 @@
         </ul></p>
       </li>
       <li><p>
-        <term>More than</term> often represents addition: 
+        <term>More than</term> often represents addition:
         <ul>
           <li>"Three more than a number" becomes <m>x+3</m></li>
         </ul></p>
@@ -50,7 +52,7 @@
         </ul></p>
       </li>
     </ul>
-
+</p>
     <example>
       <title>Number Problem</title>
         <!--Cite Beginning and Intermediate Algebra by Tyler Wallace Example 102 pg 64-->
@@ -106,7 +108,7 @@
       <p>Enter currency with a dollar sign
         <m>\$</m> in front.  If your answer is not in whole dollars, type two decimal places:
         <c>$35.50</c> and <em>not</em>
-        <c>35.5</c>. 
+        <c>35.5</c>.
       </p>
       <p>If your calculation results in more than two decimal places, round the answer to the nearest penny (hundredths):  For <m>7.386</m>, round to <c>$7.39</c>.
     </p>
@@ -127,7 +129,7 @@
           \(x=\) the mass of one atom of carbon} \amp\amp\amp \text{Convert the given information into an equation}</mrow>
         <mrow>(6.022\times 10^{23})x =12 \amp\amp\amp \text{The number of atoms times the mass of each } </mrow>
         <mrow> \text{ } \amp\amp\amp \text{equals the total mass of
-          \(12\) grams}</mrow>          
+          \(12\) grams}</mrow>
       </md>
       Now we solve the equation.
       <md>
@@ -272,7 +274,7 @@ same idea is seen in the following example.</p>
               <m>50</m>?</li>
             </ul>
         </li>
-        <li><term>Determine a number from a given percent of another number.</term> 
+        <li><term>Determine a number from a given percent of another number.</term>
           <ul>
             <li>For example,
               <m>37.5\%</m> of what number is
@@ -310,7 +312,7 @@ same idea is seen in the following example.</p>
           <m>30.</m></p>
         <p>First, think about the question.  We know that <m>50\%</m> of
           <m>30</m> is <m>15</m>.  The <term>of</term> is multiplication: <m>0.5\cdot 30 = 15</m>. We are asked to determine <m>175\%</m> of
-          <m>30</m>. Translate the words into an equation.  Let 
+          <m>30</m>. Translate the words into an equation.  Let
           <ul>
             <li><m>x=</m> the <term>unknown</term> amount we are to determine</li>
           </ul>
@@ -361,7 +363,7 @@ same idea is seen in the following example.</p>
               </mrow>
               <mrow>\text{
               ? \( \cdot 80\) \( = 10 \) ?} \amp\amp\amp \text{Let \(x\) represent the percent in decimal.}
-              </mrow> 
+              </mrow>
               <mrow>\text{
               \(x\cdot 80=10\)} \amp\amp\amp \text{solve our equation for
               \(x\): Divide both sides by
@@ -396,7 +398,7 @@ same idea is seen in the following example.</p>
                 </mrow>
                 <mrow>\text{
                 \(10\% \cdot \) ? \( = 12 \) ?} \amp\amp\amp \text{Let \(x\) represent the number.}
-                </mrow> 
+                </mrow>
                 <mrow>\text{ } \amp\amp\amp \text{
                 \(10\%\) in decimal form is \(.10\)}</mrow>
                 <mrow>
@@ -420,7 +422,7 @@ same idea is seen in the following example.</p>
           <p>Translate the words into an equation. Let
           <ul>
             <li><m>x=</m> the <term>unknown</term> number</li>
-          </ul>  
+          </ul>
           Recall <term>of</term> translates to times, and <term>is</term> translates to equals.
           <md>
             <mrow>0.375\cdot x \amp\amp\amp \text{Translate: \(37.5\%\) of the number}</mrow>
@@ -434,7 +436,7 @@ same idea is seen in the following example.</p>
     </subsection>
     <subsection>
       <title>Applications of Percent</title>
-      <p><!--Most of the time when you need to solve a percent problem, it will not be presented purely as a "percent" problem.  It will come in some setting like a Chemistry or Business problem. 
+      <p><!--Most of the time when you need to solve a percent problem, it will not be presented purely as a "percent" problem.  It will come in some setting like a Chemistry or Business problem.
         A person's salary can increase by a percentage. A town's population can decrease by a percentage. A clothing firm can discount its apparel.  -->
         Consider the following examples. Recognizing the "type" of percent problem will be the key to translating the problem into an equation.</p>
       <example>
@@ -467,13 +469,14 @@ same idea is seen in the following example.</p>
       </example>
       <p>Let us take time to summarize the steps to solve a word problem</p>
       <aside>
-         <p>When solving a word problem you'll need to </p>
+         <p>When solving a word problem you'll need to
          <ul>
           <li> Break the situation down into parts you know how to handle.</li>
           <li> Use a variable for the unknown quantity.</li>
-          <li> Build mathematical expressions from the description in the problem.</li> 
+          <li> Build mathematical expressions from the description in the problem.</li>
           <li> Put the expressions together to make an equality which you may solve with algebra operations.</li>
         </ul>
+      </p>
       </aside>
       <example>
         <title>Percent Increase</title>
@@ -499,13 +502,13 @@ same idea is seen in the following example.</p>
         </md>
       </p>
       </example>
-      The basic idea used to solve one problem may be the same in a different setting.
+      <p>The basic idea used to solve one problem may be the same in a different setting.</p>
       <example>
         <title>Sales Tax</title>
           <!-- Our own-->
         <p>Bea orders gardening tools online and <m>\$532.45</m> is charged to her credit card for the order. How much did the garden tools cost if shipping/handling is <m>8.5\%</m> of the purchase? i.e. what was the cost of just the tools?
         </p>
-        <p>First recognize this involves the same strategies used in the previous problem. We start by translating the words into an equation.  Let 
+        <p>First recognize this involves the same strategies used in the previous problem. We start by translating the words into an equation.  Let
         <ul>
           <li><m>x=</m> the <term>unknown</term> cost of the tools</li>
         </ul>
@@ -536,7 +539,7 @@ same idea is seen in the following example.</p>
           <m>\$310</m>. However, a sign in the shop indicates that skis are being discounted at
           <m>15\%.</m> What will be the new selling price of the skis?
         </p>
-        <p>First recognize this involves the first type of percent problem: <term>1. Determine a certain percent of a given number.</term> Start by translating the words into an equation.  Let 
+        <p>First recognize this involves the first type of percent problem: <term>1. Determine a certain percent of a given number.</term> Start by translating the words into an equation.  Let
         <ul>
           <li><m>x=</m> the <term>unknown</term> selling price</li>
         </ul>
@@ -562,7 +565,7 @@ same idea is seen in the following example.</p>
       <title>Computing Desired Score for a Minimum Average</title>
 <!-- Our own-->
       <p>Suppose your scores on <m>2</m> homework assignments are <m>89</m> and <m>85</m>.  What minimum score should you achieve on your third assignment if you desire the average of the <m>3</m> assignments to be at least <m>90</m>?</p>
-      <p>Let 
+      <p>Let
         <ul>
           <li><m>x</m> represent the <term>unknown</term> third score</li>
         </ul>
@@ -579,10 +582,10 @@ same idea is seen in the following example.</p>
       </p>
     </example>
 
-<p>The final course grade in <term>MAT 101</term> is a weighted average.  The final course grade is weighted by groups as follows: 
+<p>The final course grade in <term>MAT 101</term> is a weighted average.  The final course grade is weighted by groups as follows:
 <ul>
   <li><term>Attendance and Participation</term> has weight <m>5\%</m></li>
-  <li><term>Unit Exams</term> have weight <m>20\%</m></li>, and the
+  <li><term>Unit Exams</term> have weight <m>20\%</m>, and the</li>
   <li><term>Final Exam</term> has weight <m>75\%</m>.</li>
 </ul>
 Consider the computation of the following example grade:
@@ -608,7 +611,7 @@ Consider the computation of the following example grade:
   <title>Computing Desired Score for a Minimum Weighted Average</title>
 <!-- Our own-->
   <p>Suppose your <term>MAT 101</term> final course grades are as follows: Attendance and Participation <m>=100</m> and your Unit Exams average <m>=88</m>.  What minimum score should you achieve on your Final Exam if you desire your overall weighted average in MAT 101 to be at least <m>80</m>?</p>
-  <p>Let 
+  <p>Let
     <ul>
       <li><m>x</m> represent the <term>unknown</term> Final Exam score</li>
     </ul>
@@ -628,7 +631,7 @@ Consider the computation of the following example grade:
     <subsection>
     <title>Intervals in Context</title>
     <p>In this section we introduce a notation that is used in two different ways.  The correct interpretation of the notation depends on the context in which it occurs.  The notation is called the "plus or minus" sign,
-      <m>\pm.</m> 
+      <m>\pm.</m>
     </p>
     <example>
       <title>The Plus or Minus sign</title>
@@ -662,8 +665,8 @@ Consider the computation of the following example grade:
       <m>45 \pm 3</m> percent.  Here, it means that the percentage of people in favor of the idea could range any where from
       <m>42\%</m> to
       <m>48\%</m>. It's the interval
-      <m>[42, 48]</m> where the ends of the interval are calculated by 
-      <m>42=45-3</m> and 
+      <m>[42, 48]</m> where the ends of the interval are calculated by
+      <m>42=45-3</m> and
       <m>48=45+3.</m> In this case, the
       <m>\pm</m> symbol represents a range of values, not just two numbers as in the previous example.
     </p>
@@ -683,4 +686,4 @@ Consider the computation of the following example grade:
     </example>
   </subsection>
 </section>
-                     
+

--- a/src/set3A_Interpreting_Graphs.mbx
+++ b/src/set3A_Interpreting_Graphs.mbx
@@ -1,16 +1,18 @@
 <section xml:id="section-3A-graphs">
   <title>Interpreting Graphs</title>
   <introduction>
-    <ul>
-      <li>Identify the quadrants and coordinates of
-        <m>(x,y)</m> points in the Cartesian coordinate plane.
-      </li>
-      <li>Identify coordinates of solutions to linear equations.</li>
-      <li>Identify
-        <m>x</m> and
-        <m>y</m>-intercepts graphically and algebraically.
-      </li>
-    </ul>
+    <p>
+      <ul>
+        <li>Identify the quadrants and coordinates of
+          <m>(x,y)</m> points in the Cartesian coordinate plane.
+        </li>
+        <li>Identify coordinates of solutions to linear equations.</li>
+        <li>Identify
+          <m>x</m> and
+          <m>y</m>-intercepts graphically and algebraically.
+        </li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>The Cartesian Coordinate Plane</title>
@@ -42,7 +44,7 @@
             </p>
           </paragraphs>
         </sidebyside>
-        <p>Positive numbers appear to the right of the origin on the <m>x</m>-axis and negative numbers to the left. Similarly, positive numbers appear above the origin on the <m>y</m>-axis, and negative numbers below.  We can put dots on the graph to indicate points. Each point has an "address" that defines its location. The address is given as an ordered pair <m>(x,y).</m> The first number will be the value on the <m>x</m>-axis or horizontal number line. This is the distance from the point to the origin in the horizontal direction. The second number will represent the distance from the point to the origin in the vertical direction. 
+        <p>Positive numbers appear to the right of the origin on the <m>x</m>-axis and negative numbers to the left. Similarly, positive numbers appear above the origin on the <m>y</m>-axis, and negative numbers below.  We can put dots on the graph to indicate points. Each point has an "address" that defines its location. The address is given as an ordered pair <m>(x,y).</m> The first number will be the value on the <m>x</m>-axis or horizontal number line. This is the distance from the point to the origin in the horizontal direction. The second number will represent the distance from the point to the origin in the vertical direction.
         </p>
   <example>
   <title>Identify Quadrants and Coordinates</title>
@@ -235,7 +237,7 @@
         No, the point <m>(-9,7)</m> <em>is not</em> a solution. <m>\checkmark</m>
       </p>
       </example>
-      <p>Equations do not always use the varibles 
+      <p>Equations do not always use the varibles
         <m>x</m> and <m>y</m>, but as long as we know which represents the horizontal distance and which the vertical, we may plot a graph to represent the equation.
       </p>
           <example>
@@ -318,7 +320,7 @@
           <p>Find each
                 <m>Q</m>-coordinate by replacing
                 <m>P</m> with the given value in the equation: <m>Q = P^2-3</m></p>
-              <p> 
+              <p>
                 <m>P=-3\mapsto Q =(-3)^2-3=<!--(-3)(-3)-3=-->9-3=6</m>
                 <m>P=-1\mapsto Q =(-1)^2-3=<!--(-1)(-1)-3=-->1-3=-2</m>
                 <m>P=0\mapsto Q =(0)^2-3=<!--(0)(0)-3=-->0-3=-3</m>
@@ -392,12 +394,12 @@
         <paragraphs>
         <p>We find the <m>y</m>-value for each <m>x</m>-value:</p>
         <p>
-          <m>x=-1\mapsto y =2(-1)-3=-2-3=-5</m> 
-          <m>x=0\mapsto y =2(0)-3=0-3=-3</m> 
+          <m>x=-1\mapsto y =2(-1)-3=-2-3=-5</m>
+          <m>x=0\mapsto y =2(0)-3=0-3=-3</m>
           <m>x=1\mapsto y =2(1)-3=2-3=-1</m></p>
         </paragraphs>
       </sidebyside>
-      <p>Our table shows the points: 
+      <p>Our table shows the points:
           <m>(-1,-5), (0,-3), (1,-1)</m>
       </p>
       <sidebyside widths="55% 40%" valign="middle">
@@ -411,7 +413,7 @@
 <!--                </figure>  -->
           <paragraphs>
                 <p>We plot each point.</p>
-                <p>In  
+                <p>In
                   <xref ref="section-3B-lines" autoname="yes" />, we will see thatall solutionjs of this particular equation lie on a line.  Thus, once the points are plotted on the graph, we connect the dots to make a line.</p>
                 <p>The graph is Our Solution.<m>\checkmark</m>
                 </p>
@@ -469,7 +471,7 @@
     <m>x</m>. WE chose three integers easy to work with, but any three values can be used.
   </p>
 </sidebyside>
-<!--<table>  -->
+<sidebyside>
   <tabular>
     <col halign="right" />
     <col />
@@ -527,8 +529,8 @@
       </cell>
     </row>
   </tabular>
-<!--</table>  -->
-<!-- <table> -->
+</sidebyside>
+<sidebyside>
   <tabular>
     <col halign="right" />
     <col />
@@ -571,8 +573,8 @@
       </cell>
     </row>
   </tabular>
-<!-- </table> -->
-<!-- <table>  -->
+</sidebyside>
+<sidebyside>
   <tabular>
     <col halign="right" />
     <col />
@@ -627,7 +629,7 @@
       </cell>
     </row>
   </tabular>
-<!-- </table>  -->
+</sidebyside>
 <sidebyside widths="40% 55%" valign="middle">
 <!--  <table>  -->
     <tabular left="minor" top="minor">
@@ -689,7 +691,7 @@
           </p>
         </paragraphs>
       </sidebyside>
-    </example>                                       
+    </example>
   <p>Notice that there are two points on the graph of the equation that lie on an axis.  One is the point in the table on the
     <m>y</m>-axis and is called the
     <m>y</m>-intercept. Another is the point
@@ -820,7 +822,7 @@
     <p>Our table shows the points:
       <m>(-2,2), (-1,1), (0,0), (1,1), (2,2)</m>
     </p>
-<sidebyside widths="55% 40%" valign="middle">                                   
+<sidebyside widths="55% 40%" valign="middle">
 <!--    <figure xml:id="figure-graph-absolute-value-of-x">  -->
       <image xml:id="graph-absolute-value-of-x">
         <latex-image-code><![CDATA[\begin{tikzpicture} \draw[step=1cm,gray,very thin] (-5.9,-5.9) grid (5.9,5.9); \draw[line width=0.55mm,black,
@@ -839,7 +841,7 @@
         </paragraphs>
       </sidebyside>
     </example>
-  </subsection>                                           
+  </subsection>
 <subsection>
   <title>Intercepts</title>
   <p>Intercepts are points on the graph which lie on an axis.  Points on the
@@ -849,7 +851,7 @@
     <m>x</m>-axis will have a
     <m>y</m>-coordinate of
     <m>0</m>.
-  </p> 
+  </p>
     <example>
   <title>Determine
     <m>y</m>-Intercepts: Set
@@ -956,28 +958,26 @@
           <mrow>\amp\left(-\dfrac{2}{3}, 0\right)\amp\amp\text{Our Solution}\checkmark</mrow>
         </md>
       </p>
-      <p>
-        <sidebyside widths="40% 55%" valign="middle">
-          <p>The
-            <m>x</m>-intercept <m>\left(-\frac{2}{3} , 0\right)</m> is labeled on the graph of the equation.
-          </p>
+      <sidebyside widths="40% 55%" valign="middle">
+        <p>The
+          <m>x</m>-intercept <m>\left(-\frac{2}{3} , 0\right)</m> is labeled on the graph of the equation.
+        </p>
 <!--          <figure xml:id="figure-determine-x-intercepts">  -->
-          <image xml:id="determine-x-intercepts">
-            <latex-image-code><![CDATA[\begin{tikzpicture} \draw[step=1cm,gray,very thin] (-5.9,-5.9) grid (5.9,5.9); \draw[line width=0.55mm,black,
-              <->] (-6,0) -- (6,0) node[anchor=north west] {$x$-axis}; \draw[line width=0.55mm,black,
-                <->] (0,-6) -- (0,6) node[anchor=south east] {$y$-axis}; \foreach \x in {-4,-2,2,4} \draw[line width=0.55mm,black] (\x cm,3pt) -- (\x cm,-3pt) node[shift={(0.05,-.3)}] {$\x$}; \foreach \y in {-4,-2,2,4} \draw[line width=0.55mm,black] (3pt,\y cm) -- (-3pt,\y cm) node[shift={(-.3,0.05)}] {$\y$}; \fill[color=black] (-.67,0) circle (.15cm) node[shift={(1.4,.4)}] {\LARGE $\left(-\frac{2}{3},0\right)$}; \draw[line width=0.65mm,black,
-                  <->] (-2,-4) -- (1,5) node[shift={(-3,-1.75)}] {\LARGE $y=3x+2$}; \end{tikzpicture} ]]></latex-image-code>
-                </image>
- <!--             </figure>  -->
-            </sidebyside>
-          </p>
-            </example>
+        <image xml:id="determine-x-intercepts">
+          <latex-image-code><![CDATA[\begin{tikzpicture} \draw[step=1cm,gray,very thin] (-5.9,-5.9) grid (5.9,5.9); \draw[line width=0.55mm,black,
+            <->] (-6,0) -- (6,0) node[anchor=north west] {$x$-axis}; \draw[line width=0.55mm,black,
+              <->] (0,-6) -- (0,6) node[anchor=south east] {$y$-axis}; \foreach \x in {-4,-2,2,4} \draw[line width=0.55mm,black] (\x cm,3pt) -- (\x cm,-3pt) node[shift={(0.05,-.3)}] {$\x$}; \foreach \y in {-4,-2,2,4} \draw[line width=0.55mm,black] (3pt,\y cm) -- (-3pt,\y cm) node[shift={(-.3,0.05)}] {$\y$}; \fill[color=black] (-.67,0) circle (.15cm) node[shift={(1.4,.4)}] {\LARGE $\left(-\frac{2}{3},0\right)$}; \draw[line width=0.65mm,black,
+                <->] (-2,-4) -- (1,5) node[shift={(-3,-1.75)}] {\LARGE $y=3x+2$}; \end{tikzpicture} ]]></latex-image-code>
+              </image>
+<!--             </figure>  -->
+          </sidebyside>
+        </example>
   <p>The intercepts are points where the graph crosses an axis.  We may slightly abuse the notation and say "The
     <m>x</m>-intercept is
     <m>-\frac{2}{3}</m>" instead of referring to the point
     <m>\left( -\frac{2}{3},0\right)</m>.
   </p>
-  <p>When variables other than <m>x</m> and <m>y</m> are used in equations, we use the same process to calculate intercepts.   
+  <p>When variables other than <m>x</m> and <m>y</m> are used in equations, we use the same process to calculate intercepts.
 </p>
      <example>
         <title>Determine
@@ -985,7 +985,7 @@
         </title>
         <p>Find the
           <m>Q</m>-intercept of
-          <m>2a+5Q=8</m>.  In this case, let the vertical axis be given by <m>Q</m>. 
+          <m>2a+5Q=8</m>.  In this case, let the vertical axis be given by <m>Q</m>.
         </p>
         <p>
         <md>
@@ -1030,7 +1030,7 @@
 
 <subsection>
   <title>Equations and Graphs</title>
-There are situations where you have two (or more) equations and you need to know the values that "work" in both.  In other words, what values are solutions to both problems described by the two equations?  Alternatively, sometimes solving an equation can be thought of as finding common solutions to two equations.
+  <p>There are situations where you have two (or more) equations and you need to know the values that "work" in both.  In other words, what values are solutions to both problems described by the two equations?  Alternatively, sometimes solving an equation can be thought of as finding common solutions to two equations.</p>
 <example>
   <!--Our own -->
   <title>Points in Common</title>
@@ -1084,7 +1084,7 @@ There are situations where you have two (or more) equations and you need to know
         <m>y=\lvert x+1\rvert</m> and blue line
         <m>y=3</m> intersect at the two points
         <m>(-4,3)</m> and
-        <m>(2,3)</m>. 
+        <m>(2,3)</m>.
       </p>
       <p>Thus,
         <m>\lvert x+1\rvert =3</m> at
@@ -1126,7 +1126,7 @@ There are situations where you have two (or more) equations and you need to know
           </p>
         </paragraphs>
       </sidebyside>
-    </example>     
+    </example>
 <example>
 <title>Investigate Equation Relationships Graphically</title>
   <!-- Our own-modeled after WeBWorK 3A problem 6-->
@@ -1162,5 +1162,5 @@ There are situations where you have two (or more) equations and you need to know
 </example>
 </subsection>
 </section>
-    
-                                                                      
+
+

--- a/src/set3B_Lines.mbx
+++ b/src/set3B_Lines.mbx
@@ -1,14 +1,16 @@
 <section xml:id="section-3B-lines">
   <title>Lines</title>
   <introduction>
-    <ul>
-      <li>Determine the slope and
-        <m>y</m>-intercept of a line given a graph or two points.
-      </li>
-      <li>Determine if a line rises, falls, or is horizontal based on its slope.</li>
-      <li>Determine the slope-intercept form of a linear equation.</li>
-      <li>Compare relative steepness of lines of varying slopes.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Determine the slope and
+          <m>y</m>-intercept of a line given a graph or two points.
+        </li>
+        <li>Determine if a line rises, falls, or is horizontal based on its slope.</li>
+        <li>Determine the slope-intercept form of a linear equation.</li>
+        <li>Compare relative steepness of lines of varying slopes.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Slope</title>
@@ -167,21 +169,25 @@
       <m>y</m> coordinates of the points. Similarly, the change in the
       <m>x</m> values, we can calculate by subtracting the <m>x</m> coordinates of the points.
     </p>
-    <mdn>
-      <mrow xml:id="equation-slope">\text{The slope of a line through }
-        (x_1, y_1)\text{ and }
-        (x_2, y_2)\text{ is }
-        \dfrac{y_2-y_1}{x_2-x_1}</mrow>
-    </mdn>
+    <p>
+      <mdn>
+        <mrow xml:id="equation-slope">\text{The slope of a line through }
+          (x_1, y_1)\text{ and }
+          (x_2, y_2)\text{ is }
+          \dfrac{y_2-y_1}{x_2-x_1}</mrow>
+      </mdn>
+    </p>
     <p>When mathematicians began working with slope, it was called the modular slope. For this reason we often represent the slope with the variable
       <m>m</m>. Now we have the following formula:
-    </p>    
+    </p>
 
     <aside>
-    <mdn>
-      <mrow xml:id="equation-m-slope">\text{Slope}
-        =m=\dfrac{\text{rise}}{\text{run}}=\dfrac{\text{change in } y}{\text{change in }x} =\dfrac{y_2-y_1}{x_2-x_1}</mrow>
-      </mdn>
+      <p>
+        <mdn>
+          <mrow xml:id="equation-m-slope">\text{Slope}
+            =m=\dfrac{\text{rise}}{\text{run}}=\dfrac{\text{change in } y}{\text{change in }x} =\dfrac{y_2-y_1}{x_2-x_1}</mrow>
+        </mdn>
+      </p>
     </aside>
 
     <p>When calculating slope, it is important we subtract the <m>y</m> values and the <m>x</m> values in the same order.
@@ -194,7 +200,7 @@
           <m>(-4, 3)</m> and
           <m>(2,-9)</m>. First identify
           <m>x_1, y_1, x_2, y_2</m>.
-        
+
       <md>
         <mrow>(x_1, y_1)\amp =(-4, 3)\text{ and}</mrow>
         <mrow>(x_2,y_2)\amp =(2,-9) \amp\amp\text{Use slope formula
@@ -362,7 +368,7 @@
     <example>
       <title>Determine Equation Given Graph</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 134 pg 103-->
-      <p>
+      <!-- <p> -->
       <sidebyside widths="55% 40%" valign="middle">
 <!--        <figure xml:id="figure-determine-equation">  -->
         <image xml:id="determine-equation" source="images/determine-equation.svg">
@@ -405,7 +411,7 @@
           <p><m>y =-\dfrac{2}{3}x+3</m></p>
           <p>Our Solution<m>\checkmark</m></p>
         </sidebyside>
-      </p>
+      <!-- </p> -->
     </example>
     <p>We can also use an equation to identify the slope and
       <m>y</m>-intercept and then graph the equation using this information. To put the equation in slope-intercept form, we solve it for
@@ -427,7 +433,7 @@
         <mrow>\overline{-4}\amp\phantom{1234}\overline{-4}\phantom{1}\overline{-4} \amp\amp \text{Divide each term by
           \(-4\)}</mrow>
         <mrow>\text{Slope-intercept form: }
-          y\amp =\dfrac{1}{2}x-\dfrac{3}{2}\amp\amp \text{Slope-intercept equation 
+          y\amp =\dfrac{1}{2}x-\dfrac{3}{2}\amp\amp \text{Slope-intercept equation
           \(y=mx+b\)}</mrow>
         <mrow>\text{Slope: }
           m=\dfrac{1}{2}\amp\text{, Intercept: }
@@ -570,7 +576,6 @@
     <example>
       <title>Vertical Line Equation</title>
         <!-- Cite Beginning and Intermediate Algebra by Tyler Wallace Example 138 pg 104-->
-      <p>
       <sidebyside widths="55% 40%" valign="middle">
 <!--        <figure xml:id="figure-vertical-line">  -->
         <image xml:id="vertical-line" source="images/vertical-line.svg">
@@ -601,12 +606,10 @@
           <p><m>x=-4</m></p>
           <p>Our Solution<m>\checkmark</m></p>
         </sidebyside>
-      </p>
     </example>
     <example>
       <title>Horizontal Line Equation</title>
         <!-- Ours-->
-      <p>
       <sidebyside widths="55% 40%" valign="middle">
 <!--        <figure xml:id="figure-horizontal-line"> -->
         <image xml:id="horizontal-line" source="images/horizontal-line.svg">
@@ -639,7 +642,6 @@
           <p><m>y=2</m></p>
           <p>Our Solution<m>\checkmark</m></p>
         </sidebyside>
-      </p>
     </example>
   </subsection>
 </section>

--- a/src/set3C_Linear_Models.mbx
+++ b/src/set3C_Linear_Models.mbx
@@ -1,18 +1,20 @@
 <section xml:id="section-3C-linear-models">
   <title>Linear Models</title>
   <introduction>
-    <ul>
-      <li> Determine the slope of a given linear model and describe its meaning, in context.</li>
-      <li> Use a given linear model to solve problems.</li>
-      <li> Create a linear model from data to solve problems.</li>
-    </ul>jkku
+    <p>
+      <ul>
+        <li> Determine the slope of a given linear model and describe its meaning, in context.</li>
+        <li> Use a given linear model to solve problems.</li>
+        <li> Create a linear model from data to solve problems.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Linear Models</title>
     <p>Now that you have an understanding of lines, we will consider linear models.  A
       <term>linear model</term> is <!--an equation for--> a line that is connected to a real-world situation or data. What does this mean?
     </p>
-    <p>Recall that when we write the slope-intercept 
+    <p>Recall that when we write the slope-intercept
       equation for a line:
     <md>
       <mrow>y=mx+b</mrow>
@@ -64,7 +66,7 @@
     </p>
     <example xml:id="example-independent-dependent">
       <title>A Linear Model</title>
-      <p>Theo saved <m>\$500</m> from his summer job for spending money at college this fall.  If he spends about <m>\$20</m> per week, how long will his money last?  
+      <p>Theo saved <m>\$500</m> from his summer job for spending money at college this fall.  If he spends about <m>\$20</m> per week, how long will his money last?
         <!-- These are our own!-->
       </p>
       <p>Since the rate of change is a constant <m>-20</m> dollars per week, the model should be a line. The vertical intercept is how much he has at the beginning of the fall semester when zero weeks have passed: <m>500</m>.  The linear model is
@@ -75,13 +77,13 @@
         <md>
           <mrow>x= \text{ number of weeks}</mrow>
         </md>
-        and the response (or dependent variable) is 
+        and the response (or dependent variable) is
         <md>
           <mrow>y= \text{ amount of money left}</mrow>
         </md>
         We want to know how many weeks it will take until no money is left, when <m>y=0</m>.
           <md>
-            <mrow>0\amp= -20x+500 \amp\amp\text{Add <m>20x</m> to both sides.}</mrow>
+            <mrow>0\amp= -20x+500 \amp\amp\text{Add }20x\text{ to both sides.}</mrow>
            <mrow>20x\amp= 500 \amp\amp\text{Divide both sides by 20}</mrow>
           <mrow>x\amp= 25 \amp\amp</mrow>
           <mrow>\text{The money will be gone in }\amp 25 \text{ weeks}\amp\amp\text{Our Solution}\checkmark</mrow>
@@ -191,7 +193,7 @@
     <example xml:id="example-road-trip-slope-context">
       <title>Road Trip! Slope in Context</title>
         <!-- Our Own-->
-      <p>Continue with 
+      <p>Continue with
         <xref ref="example-road-trip-intro" autoname="yes" />. Recall the linear model
         <m>D=65t + 30</m> represents your distance
         <m>D</m> (in miles) from Caldwell
@@ -212,10 +214,10 @@
           </ul>
         </p>
       </example>
-      
+
     <example xml:id="example-road-trip-solve">
       <title>Road Trip! Solve for a Predictor Given a Response</title>
-      <p>Continue with 
+      <p>Continue with
         <xref ref="example-road-trip-intro" autoname="yes" />.  Recall the linear model
         <m>D=65t + 30</m> represents your distance
         <m>D</m> (in miles) from Caldwell
@@ -310,8 +312,8 @@
       </ul>
     </p>
   </example>
-    
-                 
+
+
     <example xml:id="eample-penguins-solve">
       <title>Penguins! Determine Response Given a Predictor</title>
         <!--Our own-->
@@ -351,7 +353,7 @@
                     \(\$3\) trillion}</mrow>
         </md>
         Since points in the plane are written
-          <m>(x,y)=(predictor, response)=(t,GDP)</m> we have 
+          <m>(x,y)=(predictor, response)=(t,GDP)</m> we have
           <md>
             <mrow>(0,3)\amp\amp\amp\text{corresponds to the year 1980 with a GDP of
                     \(\$3\) trillion}</mrow>
@@ -380,11 +382,11 @@
         <mrow>m\amp =\dfrac{3}{10}=.3\amp\amp\amp</mrow>
       </md>
       Now find the
-        <m>GDP</m>-intercept, <m>b</m>.  Since  
+        <m>GDP</m>-intercept, <m>b</m>.  Since
         <m>(0,3)</m> is the value of
         <m>GDP</m> when
         <m>t=0</m> the
-        <m>GDP</m>-intercept is 
+        <m>GDP</m>-intercept is
         <m>b=3</m>.  Putting this all together, we have
         <md>
           <mrow>GDP\amp =mt+b\amp\amp\text{The form of the linear model}</mrow>
@@ -395,11 +397,11 @@
     <example xml:id="example-GDP-solve">
       <title>Money! Solve for a Predictor Given a Response</title>
         <!--Our own-->
-      <p>Continue with the GDP 
+      <p>Continue with the GDP
         <xref ref="example-GDP-intro" autoname="yes" />. Use the linear model to determine the year when the GDP will reach
         <m>\$13.5</m> trillion.
       </p>
-      <p>Recall the response variable <m>GDP</m> represents the GDP (in trillions of dollars) at <m>t=</m> time (in years after 1980). Note we are given a GDP and asked to determine the corresponding year.  When will 
+      <p>Recall the response variable <m>GDP</m> represents the GDP (in trillions of dollars) at <m>t=</m> time (in years after 1980). Note we are given a GDP and asked to determine the corresponding year.  When will
         <m>GPD=13.5</m>? Write an equation to model the problem:
       <md>
         <mrow>GDP\amp =.3t+3\amp\amp\text{Plug the given \(GDP=13.5\) into the model}</mrow>
@@ -431,7 +433,7 @@
                     \(\$47\) for \(100\) copies}</mrow>
         </md>
         Since points in the plane are written
-          <m>(x,y)=(predictor, response)=(n,C)</m> we have 
+          <m>(x,y)=(predictor, response)=(n,C)</m> we have
           <md>
             <mrow>(100,47)\amp\amp\amp\text{corresponds to \(100\) copies with cost \(\$47\)}</mrow>
             <mrow>(259,63)\amp\amp\amp\text{corresponds to \(259\) copies with cost \(\$63\)}\checkmark</mrow>
@@ -473,8 +475,8 @@
       <title>Decimal Precision in WeBWorK</title>
       <p>It is generally a good idea to maintain
         <m>3</m> to
-        <m>5</m> decimals of accuracy when submitting answers. 
-        </p> 
+        <m>5</m> decimals of accuracy when submitting answers.
+        </p>
         <p>Note: For dollar amounts, only two decimal places will be accepted. It's still a good idea to use more accuracy when calculating your answer, then round to the nearest penny.
       </p>
     </assemblage>

--- a/src/set4A_Sets_and_Counting.mbx
+++ b/src/set4A_Sets_and_Counting.mbx
@@ -1,12 +1,14 @@
 <section xml:id="section-4A-sets-and-counting">
   <title>Sets and Counting</title>
   <introduction>
-    <ul>
-      <li>Use set operations including union, intersection and complement.</li>
-      <li>Use Venn diagrams to illustrate relations between sets.</li>
-      <li>Use set theory and Venn diagrams to solve counting problems.</li>
-      <li>Use tree diagrams and the Multiplication Axiom to solve counting problems.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Use set operations including union, intersection and complement.</li>
+        <li>Use Venn diagrams to illustrate relations between sets.</li>
+        <li>Use set theory and Venn diagrams to solve counting problems.</li>
+        <li>Use tree diagrams and the Multiplication Axiom to solve counting problems.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Sets</title>
@@ -14,7 +16,7 @@
     <p>A
       <term>set</term> is a collection of objects, and its members are called the
       <term>elements</term> of the set. We name the set by using capital letters, and enclose its members in braces
-      <m>\{\cdots\}</m>. Suppose we need to list the members of the chess club. We use the following set notation: 
+      <m>\{\cdots\}</m>. Suppose we need to list the members of the chess club. We use the following set notation:
       <md>
         <mrow>C=\{\text{Ken, Bob, Tran, Shanti, Eric}\}</mrow>
       </md>
@@ -193,11 +195,11 @@
                     <m>-3</m> is in the top interval
                     <m>(-\infty, 2]</m>, so
                     <m>-3</m> is in the union.</p>
-                  <p>Also 
+                  <p>Also
                     <m>2.7</m> is in the bottom interval
                     <m>(-2, \infty)</m>, so
                     <m>2.7</m> is in the union.</p>
-                  <p>And 
+                  <p>And
                     <m>-\frac{1}{3}</m> is in both intervals, so
                     <m>-\frac{1}{3}</m> is in the union.</p>
                 </paragraphs>
@@ -211,10 +213,10 @@
               </example>
               <assemblage>
                 <title>WeBWorK: Entering all Real Numbers</title>
-                <p>Type 
+                <p>Type
                   <c>(-inf,inf)</c> for the interval <m>(-\infty, \infty)</m>.
                 </p>
-                <p>Type 
+                <p>Type
                   <c>-inf &lt; x &lt; inf</c> for the inequality <m>-\infty \lt x \lt \infty</m>.
                 </p>
                 <p>Equivalently, you may type <c>all real numbers</c>.</p>
@@ -234,7 +236,7 @@
                     <m>-3</m> is NOT in the bottom interval
                     <m>(-2, \infty),</m> so
                     <m>-3</m> is NOT in the intersection.</p>
-                  <p>Also, 
+                  <p>Also,
                     <m>2.7</m> is NOT in the top interval
                     <m>(-\infty, 2],</m> so
                     <m>2.7</m> is NOT in the intersection.</p>
@@ -322,7 +324,7 @@
                         <!-- Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_02_CompoundIneq/42IntAlg_07_CompoundIneq.pg -->
                       <p>Describe the
                         <term>union</term> of the points in the graph.
-                      </p> 
+                      </p>
                     <sidebyside widths="55% 40%" valign="middle">
 <!--                      <figure xml:id="figure-interval-non-overlapping"> -->
                         <image xml:id="interval-non-overlapping">
@@ -334,7 +336,7 @@
                         <p>Recall the
                             <term>union</term> of the points in the graph would be all values in either the first interval OR in the second (or in both).</p>
                           </sidebyside>
-                        <p> 
+                        <p>
                           <md>
                             <mrow>(-\infty, -2]\cup [1,\infty) \amp\amp\amp \text{A union of intervals describing the union}\checkmark</mrow>
                             <mrow>x\leq -2\text{ or }x\geq 1 \amp\amp\amp \text{A compound inequality describing the union}\checkmark</mrow>
@@ -352,9 +354,9 @@
                           <c>x &lt; = -2 or x &gt; = 1</c>
                           </p>
                           <p>Be sure to include the word "or" between the solutions.
-                        </p>  
+                        </p>
                       </assemblage>
-                        
+
                         <example>
                           <title>Intersection of Two Non-Overlapping Intervals</title>
                             <!-- Modeled after and WeBWorK MAT105_Templates/setAlgebra_04_02_CompoundIneq/42IntAlg_05_CompoundIneq.pg -->
@@ -381,8 +383,8 @@
                         <p>Type
                           <c>None</c> for empty sets.
                         </p>
-                      </assemblage>  
-                      </subsection>              
+                      </assemblage>
+                      </subsection>
   <subsection>
     <title>Universal Set</title>
     <p>A
@@ -524,7 +526,7 @@
       <paragraphs>
       <p>The shaded region represents the collection of all elements that are NOT in
         <m>A.</m></p>
-        <p>The region is 
+        <p>The region is
         <m>A'.</m>
       </p>
     </paragraphs>
@@ -612,7 +614,7 @@
     </p>
   -->
 
-   
+
     <p><!--Recall a Venn diagram represents a set as the interior of a circle. Often two or more circles are enclosed in a rectangle where the rectangle represents the universal set. These diagrams allow us to visualize an intersection or union of two sets or the complement of a set.-->We will now use Venn diagrams to sort various populations and count objects.  We use the notation
       <m>n(A)</m> to represent the number of elements in set
       <m>A</m>.  For example, if <m>A=\{\text{Maggie, Joe, Ben, Susanne}\}</m> then
@@ -636,7 +638,7 @@
           <m>S</m>
           <m>=A\cap S</m>.
         </p>
-        <p>That is 
+        <p>That is
           <m>n(A\cap S)=\color{red}{12}</m>.
         </p>
       </paragraphs>
@@ -687,7 +689,7 @@
           <p>This means
             <m>x + 12 = 30</m>. Subtract
             <m>12</m> from both sides to get
-            <m>x = 18</m>. 
+            <m>x = 18</m>.
           </p>
           <p>Record
             <m>\color{blue}{18}</m> in
@@ -717,7 +719,7 @@
           <p>This means
             <m>y + 12 = 20</m>. Subtract
             <m>12</m> from both sides to get
-            <m>y = 8</m>. 
+            <m>y = 8</m>.
           </p>
           <p>Record
             <m>\color{green}{8}</m> in
@@ -738,7 +740,7 @@
 <!--      </figure>  -->
       </sidebyside>
       <sidebyside widths="45% 45%" valign="middle">
-        <p>Now that all the information is sorted out, it is easy to read from the diagram that:</p> 
+        <p>Now that all the information is sorted out, it is easy to read from the diagram that:</p>
         <p><m>\color{blue}{18}</m> people drove cars with automatic transmissions only,
           <m>\color{red}{12}</m> people drove both types of cars, and
           <m>\color{green}{8}</m> drove cars with standard transmissions only.
@@ -912,8 +914,7 @@
     </p>
     <p>Looking back at the final Venn diagram of <xref ref="example-disneyland-knotts" autoname="yes" /> in which <m>100</m> people in California were surveyed, we can organize the results in a two-way table as follows:
     </p>
-    <p>
-<!--      <table>  -->
+      <sidebyside>
         <tabular halign="center" top="minor" left="minor">
           <col halign="center" right="minor" />
           <col halign="center" right="minor" />
@@ -945,7 +946,8 @@
             <cell><m>100</m></cell>
           </row>
         </tabular>
-<!--      </table>  -->
+      </sidebyside>
+      <p>
       Notice from the above table, we can determine particular counts.  For example, at the bottom of the Disneyland column is the boxed number
       <m>\fbox{60}</m>, which is the total number of people surveyed who visited Disneyland.  The red
       <m>\color{red}{6}</m> is the intersection of row Knott's and column Disneyland, which is
@@ -1390,8 +1392,7 @@
     <p>The tree diagrams help us visualize the different possibilities, but they are not practical when the possibilities are numerous. Besides, we are mostly interested in counting the number of elements in the set and not the actual possibilities. But once the problem is envisioned, we can solve it without a tree diagram. The two examples we just solved may have given us a clue to do just that.</p>
     <p>Let us now try to solve <xref ref="example-3-step-tree" autoname="yes" /> without a tree diagram. Recall that the problem involved three steps: choosing an appetizer, choosing a main course, and choosing a dessert. The number of ways of choosing each are listed below:
     </p>
-    <p>
-<!--      <table>  -->
+    <sidebyside>
         <tabular halign="center" top="minor" left="minor">
           <col halign="center" right="minor" />
           <col halign="center" right="minor" />
@@ -1408,8 +1409,7 @@
             <cell><m>3</m></cell>
           </row>
         </tabular>
-<!--      </table>  -->
-    </p>
+      </sidebyside>
     <p>By multiplying these three numbers we get
       <m>2\cdot 4\cdot 3=24</m>, which is what we got when we did the problem using a tree diagram.  The procedure we just employed is called the <term>multiplication axiom</term>:
     </p>
@@ -1420,7 +1420,7 @@
       <m>m\cdot n</m> ways.
     </p>
     <p>The general multiplication axiom is not limited to just two tasks and can be used for any number of tasks.</p>
- 
+
   <example>
     <title>Multiplication Axiom</title>
       <!--   This is T http://cnx.org/content/col10613/1.5/ Example 11.12 page 176  -->
@@ -1428,8 +1428,7 @@
     </p>
     <p>Since there are <m>26</m> letters and <m>10</m> digits, we have the number of choices for each listed in the below table.
     </p>
-    <p>
-<!--      <table>  -->
+    <sidebyside>
         <tabular halign="center" top="minor" left="minor">
           <col halign="center" right="minor" />
           <col halign="center" right="minor" />
@@ -1452,13 +1451,14 @@
             <cell><m>10</m></cell>
           </row>
         </tabular>
-<!--      </table>  -->
-      <md>
-        <mrow>26\cdot 10 \cdot 10 \cdot 10 \cdot 10\amp\amp\amp\text{Multiply the possibilities using the Multiplication Axiom}</mrow>
-        <mrow>260,000\amp\amp\amp\text{Our Solution:}</mrow>
-        </md>
+        <p>
+          <md>
+            <mrow>26\cdot 10 \cdot 10 \cdot 10 \cdot 10\amp\amp\amp\text{Multiply the possibilities using the Multiplication Axiom}</mrow>
+            <mrow>260,000\amp\amp\amp\text{Our Solution:}</mrow>
+          </md>
       There are <m>260,000</m> possible such license plates.<m>\checkmark</m>
     </p>
+    </sidebyside>
   </example>
   <example>
     <title>Multiplication Axiom</title>
@@ -1466,8 +1466,8 @@
     <p>In how many different ways can a
       <m>3</m>-question true-false test be answered?
     </p>
-    <p>Since there are two choices for each question, we have:
-<!--    <table>  -->
+    <p>Since there are two choices for each question, we have:</p>
+    <sidebyside>
         <tabular halign="center" top="minor" left="minor">
           <col halign="center" right="minor" />
           <col halign="center" right="minor" />
@@ -1484,27 +1484,27 @@
             <cell><m>2</m></cell>
           </row>
         </tabular>
-<!--      </table>  -->
-      <md>
-        <mrow>2\cdot 2 \cdot 2\amp\amp\amp\text{Multiply the possibilities using the Multiplication Axiom}</mrow>
-        <mrow>8\amp\amp\amp\text{Our Solution: There are
-          \(8\) different ways.}\checkmark</mrow>
-      </md>
-      We list all eight possibilities below:
-      <md>
-        <mrow>TTT, TTF, TFT, TFF, FTT, FTF, FFT, FFF</mrow>
-      </md>
-      The reader should note that the first letter in each possibility is the answer corresponding to the first question, the second letter corresponds to the answer to the second question and so on. For example, <m>TFF</m>, says that the answer to the first question is given as true, and the answers to the second and third questions false.
-    </p>
-  </example>
+      </sidebyside>
+      <p>
+        <md>
+          <mrow>2\cdot 2 \cdot 2\amp\amp\amp\text{Multiply the possibilities using the Multiplication Axiom}</mrow>
+          <mrow>8\amp\amp\amp\text{Our Solution: There are
+            \(8\) different ways.}\checkmark</mrow>
+        </md>
+        We list all eight possibilities below:
+        <md>
+          <mrow>TTT, TTF, TFT, TFF, FTT, FTF, FFT, FFF</mrow>
+        </md>
+        The reader should note that the first letter in each possibility is the answer corresponding to the first question, the second letter corresponds to the answer to the second question and so on. For example, <m>TFF</m>, says that the answer to the first question is given as true, and the answers to the second and third questions false.
+      </p>
+    </example>
   <example>
     <title>Multiplication Axiom</title>
       <!--   This is T http://cnx.org/content/col10613/1.5/ Example 11.14 page 177  -->
     <p>In how many different ways can four people be seated in a row?</p>
     <p>Suppose we put four chairs in a row, and proceed to put four people in these seats.</p>
     <p>There are four choices for the first chair we choose. Once a person sits down in that chair, there are only three choices for the second chair, and so on. We list as shown below:</p>
-    <p>
-<!--      <table>  -->
+      <sidebyside>
         <tabular halign="center" top="minor" left="minor">
           <col halign="center" right="minor" />
           <col halign="center" right="minor" />
@@ -1524,7 +1524,8 @@
             <cell><m>2</m></cell>
           </row>
         </tabular>
-<!--      </table>  -->
+      </sidebyside>
+    <p>
       <md>
         <mrow>4\cdot 3\cdot 2\cdot 1\amp\amp\amp \text{Multiply the possibilities using the Multiplication Axiom}</mrow>
         <mrow>24 \amp\amp\amp\text{Our Solution: There are \(24\) different ways.}\checkmark</mrow>

--- a/src/set4B_Probability.mbx
+++ b/src/set4B_Probability.mbx
@@ -1,12 +1,14 @@
 <section xml:id="section-4B-probability">
   <title>Probability</title>
   <introduction>
-    <ul>
-      <li>Determine sample and event spaces.</li>
-      <li>Calculate probabilities using event and sample spaces.</li>
-      <li>Calculate probabilities from one- and two-way tables.</li>
-      <li>Calculate probabilities using Venn diagrams.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Determine sample and event spaces.</li>
+        <li>Calculate probabilities using event and sample spaces.</li>
+        <li>Calculate probabilities from one- and two-way tables.</li>
+        <li>Calculate probabilities using Venn diagrams.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Introduction</title>
@@ -54,9 +56,9 @@
       <term>probability</term> of event
       <m>A</m> happening is
     <mdn>
-      <mrow>P(A) = \dfrac{\text{# of outcomes in event space
-        <m>A</m>}}{\text{# of outcomes in sample space
-        <m>SS</m>}}=\dfrac{n(A)}{n(SS)}
+      <mrow>P(A) = \dfrac{\text{# of outcomes in event space }
+        A}{\text{# of outcomes in sample space }SS
+        }=\dfrac{n(A)}{n(SS)}
       </mrow>
     </mdn>
   </p>
@@ -110,8 +112,7 @@
       <p>There are two choices for each child's gender. We create a table as in Set
         <xref ref="section-4A-sets-and-counting" />.
       </p>
-      <p>
-<!--      <table>  -->
+      <sidebyside>
         <tabular halign="center" top="minor" left="minor" right="minor">
           <col right="minor" />
           <col right="minor" />
@@ -134,13 +135,15 @@
             </cell>
           </row>
         </tabular>
-<!--      </table>  --> 
+      </sidebyside>
+      <p>
       <md>
         <mrow>2\cdot 2 \cdot 2\amp\amp\amp \text{Multiply the possibilities using the
-          <term>Multiplication Axiom</term>}
+          \textbf{Multiplication Axiom}}
         </mrow>
         <mrow>8 \amp\amp\amp \text{There are \(8\) elements in the sample space.}</mrow>
       </md>
+    </p>
       <sidebyside widths="40% 55%" valign="middle">
         <paragraphs>
           <p>Illustrate the possibilities with a tree diagram. The tree has
@@ -150,12 +153,11 @@
             <m>BGB</m>, for example, indicates that the first born is a boy, the second born a girl, and the third a boy.
           </p>
         </paragraphs>
-<!--        <figure xml:id="figure-tree-gender">  -->
-          <image xml:id="tree-gender">
+        <image xml:id="tree-gender">
             <latex-image-code><![CDATA[\begin{tikzpicture} \draw (0,4) -- (3,6) node[shift={(.25,0)}] {$B$}; \draw (3.5, 6) -- (6.5,7) node[shift={(0.4,0)}] {$B$}; \draw (7.25, 7) -- (9,7.5) node[shift={(1.5,0)}] {$B\rightarrow BBB$}; \draw (7.25, 7) -- (9,6.5) node[shift={(1.5,0)}] {$G\rightarrow BBG$}; \draw (3.5, 6) -- (6.5,5) node[shift={(0.4,0)}] {$G$}; \draw (7.25, 5) -- (9,5.5) node[shift={(1.5,0)}] {$B\rightarrow BGB$}; \draw (7.25, 5) -- (9,4.5) node[shift={(1.5,0)}] {$G\rightarrow BGG$}; \draw (0,4) -- (3,2) node[shift={(.25,0)}] {$G$}; \draw (3.5, 2) -- (6.5,3) node[shift={(0.4,0)}] {$B$}; \draw (7.25, 3) -- (9,3.5) node[shift={(1.5,0)}] {$B\rightarrow GBB$}; \draw (7.25, 3) -- (9,2.5) node[shift={(1.5,0)}] {$G\rightarrow GBG$}; \draw (3.5, 2) -- (6.5,1) node[shift={(0.4,0)}] {$G$}; \draw (7.25, 1) -- (9,1.5) node[shift={(1.5,0)}] {$B\rightarrow GGB$}; \draw (7.25, 1) -- (9,.5) node[shift={(1.5,0)}] {$G\rightarrow GGG$}; \end{tikzpicture} ]]></latex-image-code>
           </image>
-<!--        </figure>  -->
       </sidebyside>
+      <p>
       <md>
         <mrow>SS=\{BBB,BBG,BGB,BGG,GBB,GBG,GGB,GGG \} \amp\amp\amp \text{Our Solution}\checkmark</mrow>
       </md>
@@ -188,7 +190,8 @@
       <p>Two fair dice are rolled. Write the sample space.
       </p>
       <p>We assume one of the dice is red, and the other green. We create a table as before:
-<!--      <table>  -->
+      </p>
+      <sidebyside>
         <tabular halign="center" top="minor" left="minor">
           <col right="minor" />
           <col right="minor" />
@@ -366,13 +369,14 @@
             </cell>
           </row>
         </tabular>
-<!--      </table>  -->
-      <md>
-        <mrow>SS=\{(1,1), (1,2),...,(6,6) \} \amp\amp\amp \text{Our Solution:}</mrow>
-      </md>
-      The sample space is the
-        <m>36=6\times 6</m> outcomes listed in the table above.
-        <m>\checkmark</m>
+      </sidebyside>
+      <p>
+        <md>
+          <mrow>SS=\{(1,1), (1,2),...,(6,6) \} \amp\amp\amp \text{Our Solution:}</mrow>
+        </md>
+        The sample space is the
+          <m>36=6\times 6</m> outcomes listed in the table above.
+          <m>\checkmark</m>
       </p>
     </example>
     <example>
@@ -416,9 +420,9 @@
         <m>4</m> suits (black spades
         <m>S</m>, black clubs
         <m>C</m>,
-        <font color="#FF0000"/>red diamonds
+        red diamonds
         <m>D</m>, and
-        <font color="#FF0000"/>red hearts
+        red hearts
         <m>H</m>) each with
         <m>13</m> cards (numbers
         <m>2</m> through
@@ -426,7 +430,7 @@
         <m>J</m>, queen
         <m>Q</m>, king
         <m>K</m>, and ace
-        <m>A</m>). We will generally consider the face cards to be the jacks, hearts, queens, kings, and aces. 
+        <m>A</m>). We will generally consider the face cards to be the jacks, hearts, queens, kings, and aces.
       </p>
       <p>
         <md>
@@ -486,8 +490,8 @@
     <example>
       <title>One-Way Table Probabilities</title>
         <!--   This is CoconinoCC_chapter_4_Probability.pdf Section 4.1 Homework Problem 1, page 113 -->
-      <p>A bag of chocolate candies contained the following distribution of colors.
-<!--      <table>  -->
+      <p>A bag of chocolate candies contained the following distribution of colors.</p>
+      <sidebyside>
         <tabular halign="center" top="minor" left="minor">
           <col right="minor" />
           <col right="minor" />
@@ -534,7 +538,8 @@
             </cell>
           </row>
         </tabular>
-<!--      </table>  -->
+      </sidebyside>
+      <p>
         If all of the candies are placed in a bowl and one is selected at random, determine the probability of selecting the following candies.</p>
         <p>(a) Determine the probability of selecting a blue candy. Label the event space <m>B</m> for blue.
         <md>
@@ -553,8 +558,8 @@
       <example xml:id="example-titanic">
         <title>Two-Way Table Probabilities</title>
         <!--   This is CoconinoCC_chapter_4_Probability.pdf Section 4.3 Homework Problem 11, page 140 -->
-        <p>The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013). Suppose a person is picked at random from the survivors.
-<!--        <table>  -->
+        <p>The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013). Suppose a person is picked at random from the survivors.</p>
+        <sidebyside>
           <tabular halign="center" top="minor" left="minor">
             <col right="minor" />
             <col right="minor" />
@@ -597,8 +602,8 @@
               <cell><m>450</m></cell>
             </row>
           </tabular>
-<!--        </table>  -->
-        Determine the following probabilities.</p>
+        </sidebyside>
+        <p>Determine the following probabilities.</p>
         <p>(a) Determine the probability that a survivor was female. Label the event space <m>F</m> for female.
         <md>
           <mrow>P(F) = \dfrac{n(F)}{\text{Total #}}=\dfrac{308}{450}\approx 0.6844\amp\amp\amp \text{Our Solution (a):}</mrow>

--- a/src/set4C_Probability_Rules.mbx
+++ b/src/set4C_Probability_Rules.mbx
@@ -1,21 +1,23 @@
 <section xml:id="section-4C-probability-rules">
   <title>Probability Rules</title>
   <introduction>
-    <ul>
-      <li>Utilize probability properties.</li>
-      <li>Calculate conditional probabilities.</li>
-      <li>Calculate probabilities using complementary events.</li>
-      <li>Calculate probabilities using addition rules.</li>
-      <li>Determine if two events are independent or dependent.</li>
-    </ul>
+    <p>
+      <ul>
+        <li>Utilize probability properties.</li>
+        <li>Calculate conditional probabilities.</li>
+        <li>Calculate probabilities using complementary events.</li>
+        <li>Calculate probabilities using addition rules.</li>
+        <li>Determine if two events are independent or dependent.</li>
+      </ul>
+    </p>
   </introduction>
   <subsection>
     <title>Probability Properties</title>
-      <!--   This is CoconinoCC_chapter_4_Probability.pdf page 116 -->The examples and WeBWorK problems of
     <p>
+      <!--   This is CoconinoCC_chapter_4_Probability.pdf page 116 -->The examples and WeBWorK problems of
       <xref ref="section-4B-probability" autoname="yes" /> demonstrated some important probability results which are summarized below.
     </p>
-    <!-- adds number <list xml:id="probability-properties"> 
+    <!-- adds number <list xml:id="probability-properties">
       <title>Probability Properties</title>-->
       <p>
       <term>Probability Properties</term>
@@ -63,7 +65,7 @@
       </p>
   <!--  </statement>
   </definition>-->
-     
+
     <example>
       <title>Complementary Events--Flu</title>
         <!--   This is CoconinoCC_chapter_4_Probability.pdf Section 4.2 Example 4.2.5(b), page 121 -->
@@ -120,27 +122,27 @@
           <mrow>P(Queen) =\dfrac{4}{52} \amp\amp\amp \text{Next use complementary events}
           </mrow>
           <mrow>P(Queen') = 1-\dfrac{4}{52}=\dfrac{38}{52}\approx  0.7308 \amp\amp\amp \text{Our Solution:}</mrow>
-          </md> 
+          </md>
           The probability of not selecting a queen is
             <m>\dfrac{38}{52}</m>or about
-            <m>73.08\%\checkmark</m>. 
+            <m>73.08\%\checkmark</m>.
           </p>
         </example>
-      
+
       <p>The complement is useful when you are trying to find the probability of an event that involves the words <em>"at least"</em> or an event that involves the words <em>"at most"</em>. As an example of an at least event is suppose you want to find the probability of making
         <em>
-          <term>at least</term> 
+          <term>at least</term>
         </em>
         <m>\$50,000</m> when you graduate from college. That means you want the probability of your salary being greater than or equal to
         <m>\$50,000</m>. An example of an at most event is suppose you want to find the probability of rolling a die and getting
         <em>
-          <term>at most</term> 
+          <term>at most</term>
         </em>a
         <m>4</m>. That means that you want to get less than or equal to a
         <m>4</m> on the die. The reason to use the complement is that sometimes it is easier to find the probability of the complement and then subtract from
         <m>1</m>.
       </p>
-   
+
     <example>
       <title>Complementary Events--At Least</title>
         <!--   This matches our WeBWorK  -->
@@ -170,7 +172,7 @@
           The probability of rolling a sum of <em>at least</em> a
             <m>4</m> is
             <m>\dfrac{33}{36}</m> or about
-            <m>91.67\%\checkmark</m>. 
+            <m>91.67\%\checkmark</m>.
           </p>
     </example>
   </subsection>
@@ -190,7 +192,7 @@
           <md>
           <mrow>J\cap A=\{ \} \amp\amp\amp \text{The event
             \(J\cap A\) contains
-            \(0\) outcomes since you can't do that with <em>one</em> card. }
+            \(0\) outcomes since you can't do that with \emph{one} card. }
           </mrow>
           <mrow>P(J\cap A) =\dfrac{0}{52} \amp\amp\amp \text{Our Solution (a):}</mrow>
         </md>
@@ -200,7 +202,7 @@
           <p>(b) Determine the probability of selecting a Jack
             <m>J</m> OR an Ace
             <m>A</m>. First write the event space,
-            <m>J\cup A</m>. 
+            <m>J\cup A</m>.
           <md>
           <mrow>J\cup A=\{JS, JC, JD, JH, AS, AC, AD, AH \} \amp\amp\amp \text{The event
             \(J\cup A\) contains
@@ -215,7 +217,7 @@
           <p>(c) Determine the probability of selecting a Spade
             <m>S</m> OR an Ace
             <m>A</m>. First write the event space,
-            <m>S\cup A</m>. 
+            <m>S\cup A</m>.
           <md>
           <mrow>\amp S\cup A=\amp\amp</mrow>
           <mrow>\amp\{2S, 3S, 4S, 5S, 6S, 7S, 8S, 9S, 10S,\amp\amp</mrow>
@@ -227,10 +229,10 @@
           </md>
           The probability of getting a Spade or an Ace is
             <m>\dfrac{16}{52}</m> or approximately
-            <m>30.77\%\checkmark</m>. 
+            <m>30.77\%\checkmark</m>.
           </p>
         </example>
-     
+
       <p>Part (a) of <xref ref="example-card-probabilities" autoname="yes" /> demonstrates an
         <term>impossible event</term>: selecting a Jack and an Ace on one draw.  Parts (b) and (c) demonstrate another probability concept.  Notice that:
       </p>
@@ -263,8 +265,8 @@
     <example>
       <title>Mutually Exclusive</title>
       <!--   This is CoconinoCC_chapter_4_Probability.pdf Section 4.3 Homework Problem 11, page 140 -->
-      <p>(Recall Example <xref ref="example-titanic" autoname="yes" />.) The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013).
- <!--       <table>  -->
+      <p>(Recall Example <xref ref="example-titanic" autoname="yes" />.) The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013).</p>
+      <sidebyside>
           <tabular halign="center" top="minor" left="minor">
             <col right="minor" />
             <col right="minor" />
@@ -307,8 +309,8 @@
               <cell><m>450</m></cell>
             </row>
           </tabular>
-<!--        </table>  -->
-        Determine if the events survivor is a female and survivor is in the first class are mutually exclusive.</p>
+        </sidebyside>
+        <p>Determine if the events survivor is a female and survivor is in the first class are mutually exclusive.</p>
       <p>Label the event spaces
             <m>F</m> for female and
             <m>1st</m> for first class.
@@ -345,8 +347,8 @@
     <example>
       <title>Conditional Probability--Titanic</title>
       <!--   This is CoconinoCC_chapter_4_Probability.pdf Section 4.3 Homework Problem 11, page 140 -->
-      <p>(Recall <xref ref="example-titanic" autoname="yes" />.) The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013). Suppose a person is picked at random from the survivors.
-<!--        <table>  -->
+      <p>(Recall <xref ref="example-titanic" autoname="yes" />.) The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013). Suppose a person is picked at random from the survivors.</p>
+      <sidebyside>
           <tabular halign="center" top="minor" left="minor">
             <col right="minor" />
             <col right="minor" />
@@ -389,10 +391,10 @@
               <cell><m>450</m></cell>
             </row>
           </tabular>
-<!--        </table>  -->
-      Determine the following probabilities.</p>
+        </sidebyside>
+      <p>Determine the following probabilities.</p>
       <p>(a) Determine the probability that a survivor was in the first class. Label the event space
-            <m>1st</m> for first class. 
+            <m>1st</m> for first class.
           <md>
           <mrow>P(1st) = \dfrac{n(1st)}{\text{Total #}}=\dfrac{193}{450}\approx 0.4289 \amp\amp\amp \text{Our Solution (a):}</mrow>
           </md>
@@ -483,7 +485,7 @@
         <m>2</m> are called
         <term>dependent events</term>.
       </p>
-   
+
   </subsection>
   <subsection>
     <title>Independent Events</title>
@@ -509,8 +511,8 @@
     <example>
       <title>Independent Events--Titanic</title>
       <!--   This is CoconinoCC_chapter_4_Probability.pdf Section 4.3 Homework Problem 11, page 140 -->
-      <p>(Recall <xref ref="example-titanic" autoname="yes" />.) The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013). Suppose a person is picked at random from the survivors.
-<!--        <table>  -->
+      <p>(Recall <xref ref="example-titanic" autoname="yes" />.) The number of people who survived the Titanic based on class and gender is in the below table ("Encyclopedia Titanica," 2013). Suppose a person is picked at random from the survivors.</p>
+      <sidebyside>
           <tabular halign="center" top="minor" left="minor">
             <col right="minor" />
             <col right="minor" />
@@ -553,8 +555,8 @@
               <cell><m>450</m></cell>
             </row>
           </tabular>
-<!--        </table>  -->
-      Determine if the events <em>"survivor is a female"</em> and <em>"survivor is in first class"</em> are independent.</p>
+        </sidebyside>
+      <p>Determine if the events <em>"survivor is a female"</em> and <em>"survivor is in first class"</em> are independent.</p>
       <p>Label the event spaces
             <m>F</m> for female and
             <m>1st</m> for first class. Compute both
@@ -649,7 +651,7 @@
             <li><m>B</m> represent a boy kitten</li>
             <li><m>G</m> represent a girl kitten</li>
           </ul>
-         Illustrate the possibilities with a tree diagram.
+         Illustrate the possibilities with a tree diagram.</p>
           <sidebyside widths="40% 55%" valign="middle" margins="0%">
           <paragraphs>
             <p>The tree has
@@ -660,50 +662,50 @@
           </paragraphs>
           <image source="images/tree-gender.svg" />
         </sidebyside>
-        We are told <m>P(B)=0.03</m>. Determine the probability of a girl using complementary events, since
+        <p>We are told <m>P(B)=0.03</m>. Determine the probability of a girl using complementary events, since
             <m>B'=G</m>.
           <md>
           <mrow>P(G)=P(B')=1-P(B)=1-0.03=0.97</mrow></md>
           Label the corresponding branches of the tree.
-          <sidebyside widths="40% 55%" valign="middle" margins="0%">
-          <paragraphs>
-            <p>Each branch with an outcome of
-            <m>B</m> has a
-            <m>0.03</m> chance of occurring.
-            </p>
-            <p>Each branch with an outcome of
-            <m>G</m> has a
-            <m>0.97</m> chance of occurring.</p>
-          </paragraphs>
+        </p>
+        <sidebyside widths="40% 55%" valign="middle" margins="0%">
+        <paragraphs>
+          <p>Each branch with an outcome of
+          <m>B</m> has a
+          <m>0.03</m> chance of occurring.
+          </p>
+          <p>Each branch with an outcome of
+          <m>G</m> has a
+          <m>0.97</m> chance of occurring.</p>
+        </paragraphs>
 <!--      <figure xml:id="figure-probability-tree-gender">  -->
-            <image xml:id="probability-tree-gender">
-              <latex-image-code><![CDATA[
-                      \begin{tikzpicture}
-                        \draw (0,4) -- (3,6) node[shift={(.25,0)}] {$B$} node[shift={(-1.5,-.6)}] {$0.03$};
-                        \draw (3.5, 6) -- (6.5,7) node[shift={(0.4,0)}] {$B$} node[shift={(-1.5,-.2)}] {$0.03$};
-                        \draw (7.25, 7) -- (9,7.5) node[shift={(1.5,0)}] {$B\rightarrow BBB$} node[shift={(-1,-.025)}] {$0.03$};
-                        \draw (7.25, 7) -- (9,6.5) node[shift={(1.5,0)}] {$G\rightarrow BBG$} node[shift={(-1,.025)}] {$0.97$};
+          <image xml:id="probability-tree-gender">
+            <latex-image-code><![CDATA[
+                    \begin{tikzpicture}
+                      \draw (0,4) -- (3,6) node[shift={(.25,0)}] {$B$} node[shift={(-1.5,-.6)}] {$0.03$};
+                      \draw (3.5, 6) -- (6.5,7) node[shift={(0.4,0)}] {$B$} node[shift={(-1.5,-.2)}] {$0.03$};
+                      \draw (7.25, 7) -- (9,7.5) node[shift={(1.5,0)}] {$B\rightarrow BBB$} node[shift={(-1,-.025)}] {$0.03$};
+                      \draw (7.25, 7) -- (9,6.5) node[shift={(1.5,0)}] {$G\rightarrow BBG$} node[shift={(-1,.025)}] {$0.97$};
 
-                        \draw (3.5, 6) -- (6.5,5) node[shift={(0.4,0)}] {$G$} node[shift={(-1.5,.15)}] {$0.97$};
-                        \draw (7.25, 5) -- (9,5.5) node[shift={(1.5,0)}] {$B\rightarrow BGB$} node[shift={(-1,-.025)}] {$0.03$};
-                        \draw (7.25, 5) -- (9,4.5) node[shift={(1.5,0)}] {$G\rightarrow BGG$} node[shift={(-1,.025)}] {$0.97$};
+                      \draw (3.5, 6) -- (6.5,5) node[shift={(0.4,0)}] {$G$} node[shift={(-1.5,.15)}] {$0.97$};
+                      \draw (7.25, 5) -- (9,5.5) node[shift={(1.5,0)}] {$B\rightarrow BGB$} node[shift={(-1,-.025)}] {$0.03$};
+                      \draw (7.25, 5) -- (9,4.5) node[shift={(1.5,0)}] {$G\rightarrow BGG$} node[shift={(-1,.025)}] {$0.97$};
 
-                        \draw (0,4) -- (3,2) node[shift={(.25,0)}] {$G$} node[shift={(-1.5,.55)}] {$0.97$};
-                        \draw (3.5, 2) -- (6.5,3) node[shift={(0.4,0)}] {$B$} node[shift={(-1.5,-.2)}] {$0.03$};
-                        \draw (7.25, 3) -- (9,3.5) node[shift={(1.5,0)}] {$B\rightarrow GBB$} node[shift={(-1,-.025)}] {$0.03$};
-                        \draw (7.25, 3) -- (9,2.5) node[shift={(1.5,0)}] {$G\rightarrow GBG$} node[shift={(-1,.025)}] {$0.97$};
+                      \draw (0,4) -- (3,2) node[shift={(.25,0)}] {$G$} node[shift={(-1.5,.55)}] {$0.97$};
+                      \draw (3.5, 2) -- (6.5,3) node[shift={(0.4,0)}] {$B$} node[shift={(-1.5,-.2)}] {$0.03$};
+                      \draw (7.25, 3) -- (9,3.5) node[shift={(1.5,0)}] {$B\rightarrow GBB$} node[shift={(-1,-.025)}] {$0.03$};
+                      \draw (7.25, 3) -- (9,2.5) node[shift={(1.5,0)}] {$G\rightarrow GBG$} node[shift={(-1,.025)}] {$0.97$};
 
-                        \draw (3.5, 2) -- (6.5,1) node[shift={(0.4,0)}] {$G$} node[shift={(-1.5,.15)}] {$0.97$};
-                        \draw (7.25, 1) -- (9,1.5) node[shift={(1.5,0)}] {$B\rightarrow GGB$} node[shift={(-1,-.025)}] {$0.03$};
-                        \draw (7.25, 1) -- (9,.5) node[shift={(1.5,0)}] {$G\rightarrow GGG$} node[shift={(-1,.025)}] {$0.97$};
-                                  \end{tikzpicture} ]]></latex-image-code>
-                        </image>
+                      \draw (3.5, 2) -- (6.5,1) node[shift={(0.4,0)}] {$G$} node[shift={(-1.5,.15)}] {$0.97$};
+                      \draw (7.25, 1) -- (9,1.5) node[shift={(1.5,0)}] {$B\rightarrow GGB$} node[shift={(-1,-.025)}] {$0.03$};
+                      \draw (7.25, 1) -- (9,.5) node[shift={(1.5,0)}] {$G\rightarrow GGG$} node[shift={(-1,.025)}] {$0.97$};
+                                \end{tikzpicture} ]]></latex-image-code>
+                      </image>
 <!--                      </figure>  -->
-        </sidebyside>
-      </p>
+      </sidebyside>
       <p>(a) Determine the probability of all
             <m>3</m> calico kittens being boys. Multiply the probabilities along the path to the outcome
-            <m>BBB</m>. 
+            <m>BBB</m>.
           <md>
           <mrow>P(BBB)=(0.03)(0.03)(0.03) = 0.000027 \amp\amp\amp \text{Our Solution (a):}</mrow>
           </md>
@@ -716,14 +718,14 @@
             <m>GGG</m>. All of the other outcomes have at least one male kitten.  This means the event <em>"at least one boy"</em> is the complement of the event
             <m>GGG</m>. Use the complement:
             <m>P(\text{at least one boy})=1-P(GGG)</m>. Multiply the probabilities along the path to the outcome
-            <m>GGG</m>. 
+            <m>GGG</m>.
           <md>
           <mrow>\amp P(GGG)= (0.97)(0.97)(0.97)\approx 0.9127 \amp\amp \text{Now use the complement}</mrow>
           <mrow>\amp P(\text{at least one boy})=1-P(GGG)=\amp\amp</mrow>
           <mrow>\amp 1-(0.97)^3\approx 1-0.9127=0.0873 \amp\amp \text{Our Solution (b):}</mrow>
             </md>
             The probability of at least one of the calico kittens being a boy is approximately
-            <m>8.73\%\checkmark</m>. 
+            <m>8.73\%\checkmark</m>.
           </p>
     </example>
   </subsection>


### PR DESCRIPTION
Almost all the errors were of the following types: (try to unlearn these habits since these are all permanent changes in PreTeXt):

1. Naked `tabular`/`image`: to get a `tabular` or `image` without a caption, make it the unique child of a `sidebyside`
2. Naked `md`/`mdn`/`ol`/`ul`: these must be wrapped in `p`
3. Improper nesting of `m`: Can't use it inside `\text{...}` inside other `m` (or any other PreTeXt syntax)